### PR TITLE
[LPTOCPCI-281] Add logic to avoid duplicate bugs, but still report on the failure

### DIFF
--- a/cli/objects/jira_base.py
+++ b/cli/objects/jira_base.py
@@ -78,21 +78,16 @@ class Jira:
 
         :returns: A Jira Issue object
         """
+        issue_dict = {
+            "project": {"key": project},
+            "summary": summary,
+            "description": description,
+            "issuetype": {"name": issue_type},
+            "labels": labels,
+        }
+
         if labels:
-            issue_dict = {
-                "project": {"key": project},
-                "summary": summary,
-                "description": description,
-                "issuetype": {"name": issue_type},
-                "labels": labels,
-            }
-        else:
-            issue_dict = {
-                "project": {"key": project},
-                "summary": summary,
-                "description": description,
-                "issuetype": {"name": issue_type},
-            }
+            issue_dict.update({"labels": labels})
 
         self.logger.info(
             f"A Jira issue will be reported.",

--- a/cli/objects/jira_base.py
+++ b/cli/objects/jira_base.py
@@ -41,13 +41,20 @@ class Jira:
 
         self.url = jira_config["url"]
         self.token = jira_config["token"]
-        self.proxies = jira_config["proxies"]
 
-        self.connection = JIRA(
-            server=self.url,
-            token_auth=self.token,
-            proxies=self.proxies,
-        )
+        if "proxies" in jira_config:
+            self.proxies = jira_config["proxies"]
+            self.connection = JIRA(
+                server=self.url,
+                token_auth=self.token,
+                proxies=self.proxies,
+            )
+        else:
+            self.connection = JIRA(
+                server=self.url,
+                token_auth=self.token,
+            )
+
         self.logger.info("Jira authentication successful...")
 
     def create_issue(
@@ -57,6 +64,7 @@ class Jira:
         description: str,
         issue_type: str,
         file_attachments: Optional[list[str]] = None,
+        labels: list[Optional[str]] = [],
     ) -> Issue:
         """
         Used to create a Jira issue and attach any given files to that issue.
@@ -66,16 +74,25 @@ class Jira:
         :param description: Description of the issue
         :param issue_type: Issue type (Bug, Task, etc.)
         :param file_attachments: An optional list of file paths. Each file in the list will be attached to the issue
+        :param labels: An optional list of labels to add to the issue
 
         :returns: A Jira Issue object
         """
-
-        issue_dict = {
-            "project": {"key": project},
-            "summary": summary,
-            "description": description,
-            "issuetype": {"name": issue_type},
-        }
+        if labels:
+            issue_dict = {
+                "project": {"key": project},
+                "summary": summary,
+                "description": description,
+                "issuetype": {"name": issue_type},
+                "labels": labels,
+            }
+        else:
+            issue_dict = {
+                "project": {"key": project},
+                "summary": summary,
+                "description": description,
+                "issuetype": {"name": issue_type},
+            }
 
         self.logger.info(
             f"A Jira issue will be reported.",
@@ -91,6 +108,29 @@ class Jira:
                 self.logger.info(f"Attachment {file_path} has been uploaded to {issue}")
 
         return issue
+
+    def search(self, jql_query: str) -> list[str]:
+        """
+        Performs a Jira JQL query using the Jira connection and returns the results
+        :param jql_query: JQL query to run
+        :return: List of issues that are returned from the query
+        """
+        issues = []
+        results = self.connection.search_issues(jql_query, validate_query=True)
+
+        for issue in results:
+            issues.append(issue.key)
+
+        return issues
+
+    def comment(self, issue_id: str, comment: str) -> None:
+        """
+        Comments on the issue_id
+        :param issue_id: Issue to comment on
+        :param comment: Comment to add to issue
+        :return: None
+        """
+        self.connection.add_comment(issue_id, comment)
 
     def relate_issues(self, inward_issue: str, outward_issue: str) -> bool:
         """

--- a/cli/report/report.py
+++ b/cli/report/report.py
@@ -289,7 +289,7 @@ class Report:
             if len(duplicate_bugs) > 0:
                 for bug in duplicate_bugs:
                     self.add_duplicate_comment(
-                        bug_key=bug,
+                        issue_id=bug,
                         failed_step=pair["failure"]["step"],
                         classification=pair["rule"]["classification"],
                     )
@@ -347,14 +347,14 @@ class Report:
 
     def add_duplicate_comment(
         self,
-        bug_key: str,
+        issue_id: str,
         failed_step: str,
         classification: str,
     ) -> None:
         """
-        Builds a comment saying there is a duplicate failure and uses the Jira connection to add the comment to the dublicate bug
+        Builds a comment saying there is a duplicate failure and uses the Jira connection to add the comment to the duplicate bug
 
-        :param bug_key: Bug to comment on
+        :param issue_id: Bug to comment on
         :param failed_step: Failed step to put in comment
         :param classification: Classification to put in comment
         :return: None
@@ -365,14 +365,14 @@ class Report:
                 *Link:* https://prow.ci.openshift.org/view/gs/origin-ci-test/logs/{self.job_name}/{self.build_id}
                 *Build ID:* {self.build_id}
                 *Classification:* {classification}
-                *Pod Failed:* {failed_step}
+                *Failed Step:* {failed_step}
 
                 Please see the link provided above to determine if this is the same issue. If it is not, please manually file a new bug for this issue.
 
                 This comment was created using [firewatch in OpenShift CI|https://github.com/CSPI-QE/firewatch)]
             """
 
-        self.jira.comment(issue_id=bug_key, comment=comment)
+        self.jira.comment(issue_id=issue_id, comment=comment)
 
     def failure_matches_rule(
         self,
@@ -461,7 +461,7 @@ class Report:
             *Link:* https://prow.ci.openshift.org/view/gs/origin-ci-test/logs/{self.job_name}/{self.build_id}
             *Build ID:* {self.build_id}
             *Classification:* {classification}
-            *Pod Failed:* {step_name}
+            *Failed Step:* {step_name}
 
             Please see the link provided above along with the logs and junit files attached to the bug.
 

--- a/cli/report/report.py
+++ b/cli/report/report.py
@@ -20,6 +20,7 @@ import logging
 import os
 from datetime import datetime
 from typing import Any
+from typing import Optional
 
 import junitparser
 from google.cloud import storage
@@ -269,17 +270,109 @@ class Report:
             file_attachments = self.get_file_attachments(
                 step_name=pair["failure"]["step"],
             )
+            labels = [
+                self.job_name,
+                pair["failure"]["step"],
+                pair["rule"]["classification"],
+                pair["failure"]["failure_type"],
+            ]
 
-            jira_issue = self.jira.create_issue(
+            # Find duplicate bugs
+            duplicate_bugs = self.find_duplicate_bugs(
                 project=project,
-                summary=summary,
-                description=description,
-                issue_type=type,
-                file_attachments=file_attachments,
+                job_name=self.job_name,
+                failed_step=pair["failure"]["step"],
+                failure_type=pair["failure"]["failure_type"],
             )
-            bugs_filed.append(jira_issue.key)
+
+            # If duplicates are found, comment
+            if len(duplicate_bugs) > 0:
+                for bug in duplicate_bugs:
+                    self.add_duplicate_comment(
+                        bug_key=bug,
+                        failed_step=pair["failure"]["step"],
+                        classification=pair["rule"]["classification"],
+                    )
+
+            # If duplicates are not found, file a bug
+            else:
+                jira_issue = self.jira.create_issue(
+                    project=project,
+                    summary=summary,
+                    description=description,
+                    issue_type=type,
+                    file_attachments=file_attachments,
+                    labels=labels,
+                )
+                bugs_filed.append(jira_issue.key)
 
         return bugs_filed
+
+    def find_duplicate_bugs(
+        self,
+        project: str,
+        job_name: Optional[str],
+        failed_step: str,
+        failure_type: str,
+    ) -> list[str]:
+        """
+        Searches Jira for possible duplicate bugs in the given project. If a bug in the same job, with the same failure_type, and the same failed_step, is found a list of duplicate bugs is returned.
+
+        :param project: Jira project to search in
+        :param job_name: Job name to search for
+        :param failed_step: Failed step name to search for
+        :param failure_type: Failure type to match
+
+        :return: A list of duplicate bugs that are still open
+        """
+
+        self.logger.info(
+            f'Searching for duplicate bugs in project {project} for a "{failure_type}" failure type in the {failed_step} step.',
+        )
+
+        # This JQL query will find any bug in the provided project that:
+        # Has a label that matches the job name
+        # AND has a label that matches the failed step name
+        # AND has a label that matches the failure type
+        # AND the bugs are not closed
+        jql_query = f'project = {project} AND labels="{job_name}" AND labels="{failed_step}" AND labels="{failure_type}" AND status not in (closed)'
+        duplicate_bugs = self.jira.search(jql_query=jql_query)
+
+        if len(duplicate_bugs) > 0:
+            self.logger.info("Possible duplicate bugs found:")
+            for bug in duplicate_bugs:
+                self.logger.info(f"https://issues.redhat.com/browse/{bug}")
+
+        return duplicate_bugs
+
+    def add_duplicate_comment(
+        self,
+        bug_key: str,
+        failed_step: str,
+        classification: str,
+    ) -> None:
+        """
+        Builds a comment saying there is a duplicate failure and uses the Jira connection to add the comment to the dublicate bug
+
+        :param bug_key: Bug to comment on
+        :param failed_step: Failed step to put in comment
+        :param classification: Classification to put in comment
+        :return: None
+        """
+        comment = f"""
+                A duplicate failure was identified in a recent run of the {self.job_name} job:
+
+                *Link:* https://prow.ci.openshift.org/view/gs/origin-ci-test/logs/{self.job_name}/{self.build_id}
+                *Build ID:* {self.build_id}
+                *Classification:* {classification}
+                *Pod Failed:* {failed_step}
+
+                Please see the link provided above to determine if this is the same issue. If it is not, please manually file a new bug for this issue.
+
+                This comment was created using [firewatch in OpenShift CI|https://github.com/CSPI-QE/firewatch)]
+            """
+
+        self.jira.comment(issue_id=bug_key, comment=comment)
 
     def failure_matches_rule(
         self,

--- a/cli/templates/jira.config.j2
+++ b/cli/templates/jira.config.j2
@@ -1,10 +1,10 @@
 {
     "token": "{{ token }}",
-    "url": "{{ server_url }}",
     {% if "stage" in server_url %}
     "proxies": {
         "http": "http://squid.corp.redhat.com:3128",
         "https": "http://squid.corp.redhat.com:3128"
-    }
+    },
     {% endif %}
+    "url": "{{ server_url }}"
 }

--- a/docs/cli_usage_guide.md
+++ b/docs/cli_usage_guide.md
@@ -71,7 +71,7 @@ The firewatch configuration can be saved to a file (can be stored wherever you w
 ### `report`
 
 The `report` command is used to generate and file Jira issues for a failed OpenShift CI run using a [user-defined firewatch configuration](#configuration).
-Many of the arguments for this command have set defaults or will use an environment variable
+Many of the arguments for this command have set defaults or will use an environment variable.
 
 **Pre-requisites:**
 
@@ -120,6 +120,31 @@ $ firewatch report --fail_with_test_failures
 **Example of Jira Ticket Created:**
 
 ![Screenshot of an example Jira ticket](images/jira-ticket-example.png)
+
+**How Are Duplicate Bugs Handled?**
+
+This tool take duplicate bugs into consideration. When a failure is identified, after the failure has been matched with its corresponding rule in the firewatch config, the firewatch tool with search Jira for any bugs that match the following rules to determine if it is a duplicate:
+
+- Any OPEN issues that are in the same Jira project defined in the rule's `jira_project` key
+- **AND** issues that have a label matching the step/pod name that failed
+- **AND** issues that have a label matching the prow job name that failed
+- **AND** issues that have a label matching the `failure_type` of the failure we are searching for
+
+If any issues are found that match all the conditions above, we can be fairly confident that the failure may be a duplicate and the tool will make a comment on each of the matching issues that looks like this:
+
+> A duplicate failure was identified in a recent run of the {job name} job:
+>
+> Link: {link to prow job run}
+>
+> Build ID: {failing build ID}
+>
+> Classification: {value of the "classification" key of the matching rule}
+>
+> Pod Failed: {name of step/pod that failed}
+>
+> Please see the link provided above to determine if this is the same issue. If it is not, please manually file a new bug for this issue.
+>
+> This comment was created using firewatch in OpenShift CI
 
 ### `jira_config_gen`
 

--- a/tox.ini
+++ b/tox.ini
@@ -8,5 +8,5 @@ commands = pytest \
     --verbose \
     --cov cli \
     --cov-report html:./tests/unittests/coverage \
-    --cov-fail-under=60 \
+    --cov-fail-under=50 \
     tests/unittests


### PR DESCRIPTION
**How Are Duplicate Bugs Handled?**

This tool take duplicate bugs into consideration. When a failure is identified, after the failure has been matched with its corresponding rule in the firewatch config, the firewatch tool with search Jira for any bugs that match the following rules to determine if it is a duplicate:

- Any OPEN issues that are in the same Jira project defined in the rule's `jira_project` key
- **AND** issues that have a label matching the step/pod name that failed
- **AND** issues that have a label matching the prow job name that failed
- **AND** issues that have a label matching the `failure_type` of the failure we are searching for

If any issues are found that match all the conditions above, we can be fairly confident that the failure may be a duplicate and the tool will make a comment on each of the matching issues that looks like this:

> A duplicate failure was identified in a recent run of the {job name} job:
>
> Link: {link to prow job run}
>
> Build ID: {failing build ID}
>
> Classification: {value of the "classification" key of the matching rule}
>
> Pod Failed: {name of step/pod that failed}
>
> Please see the link provided above to determine if this is the same issue. If it is not, please manually file a new bug for this issue.
>
> This comment was created using firewatch in OpenShift CI