### PR TITLE
[LPTOCPCI-288] Add logic for issues to be filed under an epic

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Remember, when you are using the `firewatch-report-issues` ref, some variables n
         [
             {"step": "exact-step-name", "failure_type": "pod_failure", "classification": "Infrastructure", "jira_project": "PROJECT"},
             {"step": "*partial-name*", "failure_type": "all", "classification":  "Misc.", "jira_project": "OTHER"},
-            {"step": "*ends-with-this", "failure_type": "test_failure", "classification": "Test failures", "jira_project": "TEST"}
+            {"step": "*ends-with-this", "failure_type": "test_failure", "classification": "Test failures", "jira_project": "TEST", "jira_epic": "EPIC-123"}
             {"step": "*ignore*", "failure_type": "test_failure", "classification": "NONE", "jira_project": "NONE", ignore: "true"}
         ]
     ```

--- a/cli/objects/jira_base.py
+++ b/cli/objects/jira_base.py
@@ -63,6 +63,7 @@ class Jira:
         summary: str,
         description: str,
         issue_type: str,
+        epic: Optional[str] = None,
         file_attachments: Optional[list[str]] = None,
         labels: list[Optional[str]] = [],
     ) -> Issue:
@@ -73,6 +74,7 @@ class Jira:
         :param summary: Title or summary of the issue
         :param description: Description of the issue
         :param issue_type: Issue type (Bug, Task, etc.)
+        :param epic: The epic ID (PROJECT-8) the new issue should be a part of. If not supplied, the issue will not be associated with an epic
         :param file_attachments: An optional list of file paths. Each file in the list will be attached to the issue
         :param labels: An optional list of labels to add to the issue
 
@@ -101,6 +103,17 @@ class Jira:
             for file_path in file_attachments:
                 self.connection.add_attachment(issue=issue.key, attachment=file_path)
                 self.logger.info(f"Attachment {file_path} has been uploaded to {issue}")
+
+        if epic is not None:
+            epic_search = self.connection.search_issues(f'issue="{epic}"')
+            if len(epic_search) == 1:
+                epic_id = epic_search[0].id
+                self.connection.add_issues_to_epic(
+                    epic_id=epic_id,
+                    issue_keys=issue.key,
+                )
+            else:
+                self.logger.error(f"Error finding Jira ID of epic {epic}")
 
         return issue
 

--- a/cli/report/report.py
+++ b/cli/report/report.py
@@ -261,6 +261,7 @@ class Report:
         for pair in rule_failure_pairs:
             date = datetime.now()
             project = pair["rule"]["jira_project"]
+            epic = pair["rule"]["jira_epic"] if "jira_epic" in pair["rule"] else None
             summary = f"Failure in {self.job_name}, {date.strftime('%m-%d-%Y')}"
             description = self.build_issue_description(
                 step_name=pair["failure"]["step"],
@@ -300,6 +301,7 @@ class Report:
                     summary=summary,
                     description=description,
                     issue_type=type,
+                    epic=epic,
                     file_attachments=file_attachments,
                     labels=labels,
                 )

--- a/cli/report/report.py
+++ b/cli/report/report.py
@@ -273,7 +273,6 @@ class Report:
             labels = [
                 self.job_name,
                 pair["failure"]["step"],
-                pair["rule"]["classification"],
                 pair["failure"]["failure_type"],
             ]
 

--- a/docs/cli_usage_guide.md
+++ b/docs/cli_usage_guide.md
@@ -42,8 +42,8 @@ Firewatch was designed to allow for users to define which Jira issues get create
 [
   {"step": "exact-step-name", "failure_type": "pod_failure", "classification": "Infrastructure", "jira_project": "PROJECT"},
   {"step": "*partial-name*", "failure_type": "all", "classification":  "Misc.", "jira_project": "OTHER"},
-  {"step": "*ends-with-this", "failure_type": "test_failure", "classification": "Test failures", "jira_project": "TEST"},
-  {"step": "*ignore*", "failure_type": "test_failure", "classification": "NONE", "jira_project": "NONE", ignore: "true"}
+  {"step": "*ends-with-this", "failure_type": "test_failure", "classification": "Test failures", "jira_project": "TEST", "jira_epic": "EPIC-123"},
+  {"step": "*ignore*", "failure_type": "test_failure", "classification": "NONE", "jira_project": "NONE", "ignore": "true"}
 ]
 ```
 
@@ -62,6 +62,7 @@ The firewatch configuration is a list of rules, each rule is defined using 4 val
   - `all`: Either a `pod_failure` or a `test_failure`.
 - `classification`: How you'd like to classify the issue in Jira. This is not a formal field in Jira, but will be included in the issue description. This is meant to act as a "best-guess" value for why the failure happened.
 - `jira_project`: The Jira project you'd like the issue to be filed under.
+- `jira_epic`[OPTIONAL]: The epic you would like issues to be added to. **IMPORTANT:** Any epic you use must have the automation user you are using set as a contributor in Jira. For OpenShift CI, the user is `interop-test-jenkins interop-test-jenkins`.
 - `ignore`[OPTIONAL]: A value that be set to "true" or "false" and allows the user to define `step`/`failure_type` combinations that should be ignored when creating tickets.
 
 The firewatch configuration can be saved to a file (can be stored wherever you want and named whatever you want, it must be JSON though) or defined in the `FIREWATCH_CONFIG` variable. When using the [`report` command](#report---create-jira-issues), if an argument for `--firewatch_config_path` is not provided, the environment variable will be used.


### PR DESCRIPTION
This PR allows us to specify an optional epic to file issues under using a `jira_epic` key, for example:
```json
[
  {"step": "*ends-with-this", "failure_type": "test_failure", "classification": "Test failures", "jira_project": "TEST", "jira_epic": "EPIC-123"},
]
```

> **IMPORTANT:**
> Any epic you use must have the automation user you are using set as a contributor in Jira. For OpenShift CI, the user is `interop-test-jenkins interop-test-jenkins`. 

This PR also fixes a small bug that did not allow issues to be filed if the classification had spaces in it. The issue was that a tag was being added to the issue that was the value of the classification. The API does not allow spaces in labels.