### PR TITLE
[LPTOCPCI-308] Issue Parsing XML JUnit XML from ODO Tests

### DIFF
--- a/cli/report/report.py
+++ b/cli/report/report.py
@@ -215,7 +215,7 @@ class Report:
 
                     for suite in junit_xml:
                         for case in suite:
-                            if case.result:
+                            if hasattr(case, "result") and case.result:
                                 for result in case.result:
                                     if isinstance(result, junitparser.Failure):
                                         failure = {
@@ -370,7 +370,7 @@ class Report:
 
                 Please see the link provided above to determine if this is the same issue. If it is not, please manually file a new bug for this issue.
 
-                This comment was created using [firewatch in OpenShift CI|https://github.com/CSPI-QE/firewatch)]
+                This comment was created using [firewatch in OpenShift CI|https://github.com/CSPI-QE/firewatch]
             """
 
         self.jira.comment(issue_id=issue_id, comment=comment)


### PR DESCRIPTION
Found an issue where some test cases may not have results in them. This PR fixes this issue by checking that the cases have results before utilizing that attribute. This PR also fixes a typo in the link to the firewatch repository left in the description of bugs.