### PR TITLE
[LPTOCPCI-236] Add logic to allow for issues created to be assigned a component

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Remember, when you are using the `firewatch-report-issues` ref, some variables n
     ```yaml
     FIREWATCH_CONFIG: |
         [
-            {"step": "exact-step-name", "failure_type": "pod_failure", "classification": "Infrastructure", "jira_project": "PROJECT"},
+            {"step": "exact-step-name", "failure_type": "pod_failure", "classification": "Infrastructure", "jira_project": "PROJECT", "jira_component": "some-component"},
             {"step": "*partial-name*", "failure_type": "all", "classification":  "Misc.", "jira_project": "OTHER"},
             {"step": "*ends-with-this", "failure_type": "test_failure", "classification": "Test failures", "jira_project": "TEST", "jira_epic": "EPIC-123"}
             {"step": "*ignore*", "failure_type": "test_failure", "classification": "NONE", "jira_project": "NONE", ignore: "true"}

--- a/cli/objects/jira_base.py
+++ b/cli/objects/jira_base.py
@@ -63,6 +63,7 @@ class Jira:
         summary: str,
         description: str,
         issue_type: str,
+        component: Optional[str] = None,
         epic: Optional[str] = None,
         file_attachments: Optional[list[str]] = None,
         labels: list[Optional[str]] = [],
@@ -74,6 +75,7 @@ class Jira:
         :param summary: Title or summary of the issue
         :param description: Description of the issue
         :param issue_type: Issue type (Bug, Task, etc.)
+        :param component: The component you'd like the bug to be associated with. If not supplied, the bug will not have a component
         :param epic: The epic ID (PROJECT-8) the new issue should be a part of. If not supplied, the issue will not be associated with an epic
         :param file_attachments: An optional list of file paths. Each file in the list will be attached to the issue
         :param labels: An optional list of labels to add to the issue
@@ -85,11 +87,15 @@ class Jira:
             "summary": summary,
             "description": description,
             "issuetype": {"name": issue_type},
-            "labels": labels,
         }
 
         if labels:
-            issue_dict.update({"labels": labels})
+            # MyPy spits out an odd error here unless ignored.
+            issue_dict.update({"labels": labels})  # type: ignore
+
+        if component:
+            # MyPy spits out an odd error here unless ignored.
+            issue_dict.update({"components": [{"name": component}]})  # type: ignore
 
         self.logger.info(
             f"A Jira issue will be reported.",

--- a/cli/report/report.py
+++ b/cli/report/report.py
@@ -262,6 +262,11 @@ class Report:
             date = datetime.now()
             project = pair["rule"]["jira_project"]
             epic = pair["rule"]["jira_epic"] if "jira_epic" in pair["rule"] else None
+            component = (
+                pair["rule"]["jira_component"]
+                if "jira_component" in pair["rule"]
+                else None
+            )
             summary = f"Failure in {self.job_name}, {date.strftime('%m-%d-%Y')}"
             description = self.build_issue_description(
                 step_name=pair["failure"]["step"],
@@ -301,6 +306,7 @@ class Report:
                     summary=summary,
                     description=description,
                     issue_type=type,
+                    component=component,
                     epic=epic,
                     file_attachments=file_attachments,
                     labels=labels,

--- a/docs/cli_usage_guide.md
+++ b/docs/cli_usage_guide.md
@@ -40,7 +40,7 @@ Firewatch was designed to allow for users to define which Jira issues get create
 
 ```json
 [
-  {"step": "exact-step-name", "failure_type": "pod_failure", "classification": "Infrastructure", "jira_project": "PROJECT"},
+  {"step": "exact-step-name", "failure_type": "pod_failure", "classification": "Infrastructure", "jira_project": "PROJECT", "jira_component": "some-component"},
   {"step": "*partial-name*", "failure_type": "all", "classification":  "Misc.", "jira_project": "OTHER"},
   {"step": "*ends-with-this", "failure_type": "test_failure", "classification": "Test failures", "jira_project": "TEST", "jira_epic": "EPIC-123"},
   {"step": "*ignore*", "failure_type": "test_failure", "classification": "NONE", "jira_project": "NONE", "ignore": "true"}
@@ -63,6 +63,7 @@ The firewatch configuration is a list of rules, each rule is defined using 4 val
 - `classification`: How you'd like to classify the issue in Jira. This is not a formal field in Jira, but will be included in the issue description. This is meant to act as a "best-guess" value for why the failure happened.
 - `jira_project`: The Jira project you'd like the issue to be filed under.
 - `jira_epic`[OPTIONAL]: The epic you would like issues to be added to. **IMPORTANT:** Any epic you use must have the automation user you are using set as a contributor in Jira. For OpenShift CI, the user is `interop-test-jenkins interop-test-jenkins`.
+- `jira_component`[OPTIONAL]: The component you would like issues to be added to.
 - `ignore`[OPTIONAL]: A value that be set to "true" or "false" and allows the user to define `step`/`failure_type` combinations that should be ignored when creating tickets.
 
 The firewatch configuration can be saved to a file (can be stored wherever you want and named whatever you want, it must be JSON though) or defined in the `FIREWATCH_CONFIG` variable. When using the [`report` command](#report---create-jira-issues), if an argument for `--firewatch_config_path` is not provided, the environment variable will be used.


### PR DESCRIPTION
This PR allows us to specify an optional component to file issues under using the `jira_component` key, for example:

```json
[
    {"step": "exact-step-name", "failure_type": "pod_failure", "classification": "Infrastructure", "jira_project": "PROJECT", "jira_component": "some-component"},
]
```