### PR TITLE
[LPTOCPCI-548] Allow to specify priority and assignee

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ Remember, when you are using the `firewatch-report-issues` ref, some variables n
     ```yaml
     FIREWATCH_CONFIG: |
         [
-            {"step": "exact-step-name", "failure_type": "pod_failure", "classification": "Infrastructure", "jira_project": "PROJECT", "jira_component": "some-component"},
+            {"step": "exact-step-name", "failure_type": "pod_failure", "classification": "Infrastructure", "jira_project": "PROJECT", "jira_component": "some-component", "jira_assignee": "some-user@redhat.com"},
             {"step": "*partial-name*", "failure_type": "all", "classification":  "Misc.", "jira_project": "OTHER", "jira_component": ["component-1", "component-2"]},
             {"step": "*ends-with-this", "failure_type": "test_failure", "classification": "Test failures", "jira_project": "TEST", "jira_epic": "EPIC-123", "jira_additional_labels": ["test-label-1", "test-label-2"]},
             {"step": "*ignore*", "failure_type": "test_failure", "classification": "NONE", "jira_project": "NONE", "ignore": "true"},

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ Remember, when you are using the `firewatch-report-issues` ref, some variables n
     FIREWATCH_CONFIG: |
         [
             {"step": "exact-step-name", "failure_type": "pod_failure", "classification": "Infrastructure", "jira_project": "PROJECT", "jira_component": "some-component", "jira_assignee": "some-user@redhat.com"},
-            {"step": "*partial-name*", "failure_type": "all", "classification":  "Misc.", "jira_project": "OTHER", "jira_component": ["component-1", "component-2"]},
+            {"step": "*partial-name*", "failure_type": "all", "classification":  "Misc.", "jira_project": "OTHER", "jira_component": ["component-1", "component-2"], "jira_priority": "major"},
             {"step": "*ends-with-this", "failure_type": "test_failure", "classification": "Test failures", "jira_project": "TEST", "jira_epic": "EPIC-123", "jira_additional_labels": ["test-label-1", "test-label-2"]},
             {"step": "*ignore*", "failure_type": "test_failure", "classification": "NONE", "jira_project": "NONE", "ignore": "true"},
             {"step": "affects-version", "failure_type": "all", "classification": "Affects Version", "jira_project": "TEST", "jira_epic": "EPIC-123", "jira_affects_version": "4.14"}

--- a/cli/objects/configuration.py
+++ b/cli/objects/configuration.py
@@ -94,7 +94,12 @@ class Configuration:
             exit(1)
 
     def _get_config_data(self, config_file_path: Optional[str]) -> str:
-        """"""
+        """
+        Used to get the config data from either a configuration file or from the FIREWATCH_CONFIG environment variable.
+        Will exit with code 1 if either a config file isn't provided (or isn't able to be read) or the FIREWATCH_CONFIG environment variable isn't set.
+        :param config_file_path: An optional value, the firewatch config can be stored in a file or an environment var.
+        :return: A string object representing the firewatch config data.
+        """
         if config_file_path is not None:
             # Read the contents of the config file
             try:

--- a/cli/objects/configuration.py
+++ b/cli/objects/configuration.py
@@ -48,25 +48,13 @@ class Configuration:
         self.jira = jira
 
         # Check if DEFAULT_JIRA_PROJECT
-        self.default_jira_project = (
-            os.getenv(
-                "FIREWATCH_DEFAULT_JIRA_PROJECT",
-            )
-            or "NONE"
-        )
+        self.default_jira_project = self._get_default_jira_project()
 
         # Boolean value representing if the program should fail if test failures are found.
         self.fail_with_test_failures = fail_with_test_failures
 
         # Get the config data
-        # Check if config_file_path was provided
-        if config_file_path is not None:
-            # Read the contents of the file
-            with open(config_file_path) as file:
-                self.config_data = file.read()
-        else:
-            # Check if the environment variable FIREWATCH_CONFIG is defined
-            self.config_data = os.getenv("FIREWATCH_CONFIG")  # type: ignore
+        self.config_data = self._get_config_data(config_file_path=config_file_path)
 
         # Create the list of Rule objects using the config data
         self.rules = self._get_rules(json.loads(self.config_data))
@@ -88,3 +76,42 @@ class Configuration:
                 "Firewatch config is empty, please populate the configuration and try again.",
             )
             exit(1)
+
+    def _get_default_jira_project(self) -> str:
+        """
+        Used to get the default jira project from the FIREWATCH_DEFAULT_JIRA_PROJECT environment variable
+        :return: The string of the default environment variable.
+        """
+
+        default_project = os.getenv("FIREWATCH_DEFAULT_JIRA_PROJECT")
+
+        if default_project:
+            return default_project
+        else:
+            self.logger.error(
+                "Environment variable $FIREWATCH_DEFAULT_JIRA_PROJECT is not set, please set the variable and try again.",
+            )
+            exit(1)
+
+    def _get_config_data(self, config_file_path: Optional[str]) -> str:
+        """"""
+        if config_file_path is not None:
+            # Read the contents of the config file
+            try:
+                with open(config_file_path) as file:
+                    config_data = file.read()
+                    return config_data
+            except Exception:
+                self.logger.error(
+                    f"Unable to read configuration file at {config_file_path}. Please verify permissions/path and try again.",
+                )
+                exit(1)
+        else:
+            config_data = os.getenv("FIREWATCH_CONFIG")  # type: ignore
+            if config_data:
+                return config_data
+            else:
+                self.logger.error(
+                    "A configuration file must be provided or the $FIREWATCH_CONFIG environment variable must be set. Please fix error and try again.",
+                )
+                exit(1)

--- a/cli/objects/jira_base.py
+++ b/cli/objects/jira_base.py
@@ -21,6 +21,7 @@ from typing import Optional
 from jira import Issue
 from jira import JIRA
 from jira.exceptions import JIRAError
+from jira.resources import User
 
 
 class Jira:
@@ -68,6 +69,7 @@ class Jira:
         file_attachments: Optional[list[str]] = None,
         labels: list[Optional[str]] = [],
         affects_version: Optional[str] = None,
+        assignee: Optional[str] = None,
     ) -> Issue:
         """
         Used to create a Jira issue and attach any given files to that issue.
@@ -81,6 +83,7 @@ class Jira:
         :param file_attachments: An optional list of file paths. Each file in the list will be attached to the issue
         :param labels: An optional list of labels to add to the issue
         :param affects_version: Value for version affected. Bugs created using this will populate the "Affects Version/s" field in Jira
+        :param assignee: An optional string for the assignee of an issue. Should be the email address of the user.
 
         :returns: A Jira Issue object
         """
@@ -128,6 +131,10 @@ class Jira:
                 )
             else:
                 self.logger.error(f"Error finding Jira ID of epic {epic}")
+
+        if assignee is not None:
+            self.assign_issue(user_email=assignee, issue=issue.key)
+            self.logger.info(f"Issue {issue} has been assigned to user {assignee}")
 
         return issue
 
@@ -207,3 +214,18 @@ class Jira:
             else:
                 self.logger.error(f"Error: {e.text}")
                 return False
+
+    def assign_issue(self, user_email: str, issue: str) -> bool:
+        """
+        Assigns a given issue to the user specified.
+        :param user_email: A string value representing the email address of use the issue should be assigned to.
+        :param issue: A string value representing the issue that should be assigned.
+        :return: A boolean value. If True, the issue has been assigned successfully. If false, it is not assigned.
+        """
+        # Assign the issue
+        try:
+            return self.connection.assign_issue(issue=issue, assignee=user_email)
+        except Exception as ex:
+            self.logger.error(f"Unable to assign issue {issue} to user {user_email}.")
+            self.logger.error(ex)
+            return False

--- a/cli/objects/jira_base.py
+++ b/cli/objects/jira_base.py
@@ -70,6 +70,7 @@ class Jira:
         labels: list[Optional[str]] = [],
         affects_version: Optional[str] = None,
         assignee: Optional[str] = None,
+        priority: Optional[str] = None,
     ) -> Issue:
         """
         Used to create a Jira issue and attach any given files to that issue.
@@ -84,7 +85,7 @@ class Jira:
         :param labels: An optional list of labels to add to the issue
         :param affects_version: Value for version affected. Bugs created using this will populate the "Affects Version/s" field in Jira
         :param assignee: An optional string for the assignee of an issue. Should be the email address of the user.
-
+        :param priority: An optional string representing the desired priority of the issue being created.
         :returns: A Jira Issue object
         """
         issue_dict = {
@@ -107,6 +108,9 @@ class Jira:
 
         if affects_version:
             issue_dict.update({"versions": [{"name": affects_version}]})  # type: ignore
+
+        if priority:
+            issue_dict.update({"priority": {"name": priority}})
 
         self.logger.info(
             f"A Jira issue will be reported.",

--- a/cli/objects/job.py
+++ b/cli/objects/job.py
@@ -247,7 +247,7 @@ class Job:
             steps.append(blob_step)
 
         # Return steps
-        if len(steps) > 0:
+        if len(steps) > 0 or self.is_rehearsal:
             return steps
         else:
             self.logger.error(f"No steps found for job {job_name}")

--- a/cli/objects/rule.py
+++ b/cli/objects/rule.py
@@ -42,6 +42,7 @@ class Rule:
         self.jira_affects_version = self._get_jira_affects_version(rule_dict)
         self.jira_additional_labels = self._get_jira_additional_labels(rule_dict)
         self.jira_assignee = self._get_jira_assignee(rule_dict)
+        self.jira_priority = self._get_jira_priority(rule_dict)
         self.ignore = self._get_ignore(rule_dict)
 
     def _get_step(self, rule_dict: dict[Any, Any]) -> str:
@@ -282,7 +283,6 @@ class Rule:
         :param rule_dict: A dictionary object representing a user-defined firewatch rule.
         :return: A string of the Jira assignee to use in a firewatch rule. If one is not defined, return None
         """
-        rule_dict.keys()
         if "jira_assignee" in rule_dict.keys():
             try:
                 jira_assignee = rule_dict["jira_assignee"]
@@ -300,6 +300,39 @@ class Rule:
             else:
                 self.logger.error(
                     f'Value for "jira_assignee" is not a string in firewatch rule: "{rule_dict}"',
+                )
+                exit(1)
+        else:
+            return None
+
+    def _get_jira_priority(self, rule_dict: dict[Any, Any]) -> Optional[str]:
+        """
+        Determines if a Jira priority is defined in a rule. If it is, validate it and return the string.
+
+        :param rule_dict: A dictionary object representing a user-defined firewatch rule.
+        :return: A string of the Jira priority to use in a firewatch rule. If one is not defined, return None
+        """
+        valid_priority_values = ["Blocker", "Critical", "Major", "Normal", "Minor"]
+
+        if "jira_priority" in rule_dict.keys():
+            try:
+                jira_priority = (
+                    rule_dict["jira_priority"].lower().capitalize()
+                )  # The value must be an exact match to the values in valid_priority_values (first letter capitalized, the rest lower)
+            except Exception as ex:
+                self.logger.error(ex)
+                exit(1)
+            if isinstance(jira_priority, str):
+                if jira_priority in valid_priority_values:
+                    return jira_priority
+                else:
+                    self.logger.error(
+                        f'Value for "jira_priority" is not a valid value ({valid_priority_values}) in firewatch rule: "{rule_dict}" ',
+                    )
+                    exit(1)
+            else:
+                self.logger.error(
+                    f'Value for "jira_priority" is not a string in firewatch rule: "{rule_dict}"',
                 )
                 exit(1)
         else:

--- a/cli/objects/rule.py
+++ b/cli/objects/rule.py
@@ -15,6 +15,7 @@
 #    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
 import logging
+import re
 from typing import Any
 from typing import Optional
 
@@ -290,7 +291,8 @@ class Rule:
                 self.logger.error(ex)
                 exit(1)
             if isinstance(jira_assignee, str):
-                if "@" in jira_assignee:
+                regex = r"\b[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Z|a-z]{2,7}\b"  # Used to check if email is valid
+                if re.fullmatch(regex, jira_assignee):
                     return jira_assignee
                 else:
                     self.logger.error(

--- a/cli/objects/rule.py
+++ b/cli/objects/rule.py
@@ -158,11 +158,9 @@ class Rule:
         :return: A string of the Jira epic to use in a firewatch rule. If one is not defined, return None
         """
         if "jira_epic" in rule_dict.keys():
-            try:
-                jira_epic = rule_dict["jira_epic"]
-            except Exception as ex:
-                self.logger.error(ex)
-                exit(1)
+
+            jira_epic = rule_dict["jira_epic"]
+
             if isinstance(jira_epic, str):
                 return jira_epic
             else:
@@ -182,11 +180,9 @@ class Rule:
         """
         components = []
         if "jira_component" in rule_dict.keys():
-            try:
-                jira_component = rule_dict["jira_component"]
-            except Exception as ex:
-                self.logger.error(ex)
-                exit(1)
+
+            jira_component = rule_dict["jira_component"]
+
             if isinstance(jira_component, str):
                 components.append(jira_component)
                 return components
@@ -217,11 +213,9 @@ class Rule:
         :return: A string value representing the affected version for a firewatch rule.
         """
         if "jira_affects_version" in rule_dict.keys():
-            try:
-                jira_affects_version = rule_dict["jira_affects_version"]
-            except Exception as ex:
-                self.logger.error(ex)
-                exit(1)
+
+            jira_affects_version = rule_dict["jira_affects_version"]
+
             if isinstance(jira_affects_version, str):
                 return jira_affects_version
             else:
@@ -245,11 +239,9 @@ class Rule:
         labels = []
 
         if "jira_additional_labels" in rule_dict.keys():
-            try:
-                jira_additional_labels = rule_dict["jira_additional_labels"]
-            except Exception as ex:
-                self.logger.error(ex)
-                exit(1)
+
+            jira_additional_labels = rule_dict["jira_additional_labels"]
+
             if isinstance(jira_additional_labels, str):
                 labels.append(jira_additional_labels)
                 return labels
@@ -285,11 +277,9 @@ class Rule:
         :return: A string of the Jira assignee to use in a firewatch rule. If one is not defined, return None
         """
         if "jira_assignee" in rule_dict.keys():
-            try:
-                jira_assignee = rule_dict["jira_assignee"]
-            except Exception as ex:
-                self.logger.error(ex)
-                exit(1)
+
+            jira_assignee = rule_dict["jira_assignee"]
+
             if isinstance(jira_assignee, str):
                 regex = r"\b[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Z|a-z]{2,7}\b"  # Used to check if email is valid
                 if re.fullmatch(regex, jira_assignee):
@@ -317,13 +307,11 @@ class Rule:
         valid_priority_values = ["Blocker", "Critical", "Major", "Normal", "Minor"]
 
         if "jira_priority" in rule_dict.keys():
-            try:
-                jira_priority = (
-                    rule_dict["jira_priority"].lower().capitalize()
-                )  # The value must be an exact match to the values in valid_priority_values (first letter capitalized, the rest lower)
-            except Exception as ex:
-                self.logger.error(ex)
-                exit(1)
+
+            jira_priority = (
+                rule_dict["jira_priority"].lower().capitalize()
+            )  # The value must be an exact match to the values in valid_priority_values (first letter capitalized, the rest lower)
+
             if isinstance(jira_priority, str):
                 if jira_priority in valid_priority_values:
                     return jira_priority
@@ -348,11 +336,9 @@ class Rule:
         :return: A boolean value that determines if a firewatch rule is an ignore rule. True=ignore, False=don't ignore
         """
         if "ignore" in rule_dict.keys():
-            try:
-                ignore = rule_dict["ignore"]
-            except Exception as ex:
-                self.logger.error(ex)
-                exit(1)
+
+            ignore = rule_dict["ignore"]
+
             if isinstance(ignore, str):
                 if ignore.lower() == "true":
                     return True

--- a/cli/objects/rule.py
+++ b/cli/objects/rule.py
@@ -41,6 +41,7 @@ class Rule:
         self.jira_component = self._get_jira_component(rule_dict)
         self.jira_affects_version = self._get_jira_affects_version(rule_dict)
         self.jira_additional_labels = self._get_jira_additional_labels(rule_dict)
+        self.jira_assignee = self._get_jira_assignee(rule_dict)
         self.ignore = self._get_ignore(rule_dict)
 
     def _get_step(self, rule_dict: dict[Any, Any]) -> str:
@@ -269,6 +270,36 @@ class Rule:
             else:
                 self.logger.error(
                     f'Value for "jira_additional_labels" must be either a list of strings (multiple labels) or a string value (single label) in firewatch rule: "{rule_dict}"',
+                )
+                exit(1)
+        else:
+            return None
+
+    def _get_jira_assignee(self, rule_dict: dict[Any, Any]) -> Optional[str]:
+        """
+        Determines if a Jira Assignee is defined in a rule. If it is, validate it and return the string.
+
+        :param rule_dict: A dictionary object representing a user-defined firewatch rule.
+        :return: A string of the Jira assignee to use in a firewatch rule. If one is not defined, return None
+        """
+        rule_dict.keys()
+        if "jira_assignee" in rule_dict.keys():
+            try:
+                jira_assignee = rule_dict["jira_assignee"]
+            except Exception as ex:
+                self.logger.error(ex)
+                exit(1)
+            if isinstance(jira_assignee, str):
+                if "@" in jira_assignee:
+                    return jira_assignee
+                else:
+                    self.logger.error(
+                        f'Value for "jira_assignee" is not an email address in firewatch rule: "{rule_dict}"',
+                    )
+                    exit(1)
+            else:
+                self.logger.error(
+                    f'Value for "jira_assignee" is not a string in firewatch rule: "{rule_dict}"',
                 )
                 exit(1)
         else:

--- a/cli/report/report.py
+++ b/cli/report/report.py
@@ -96,6 +96,7 @@ class Report:
             component = pair["rule"].jira_component  # type: ignore
             affects_version = pair["rule"].jira_affects_version  # type: ignore
             assignee = pair["rule"].jira_assignee  # type: ignore
+            priority = pair["rule"].jira_priority  # type: ignore
             summary = f"Failure in {job.name}, {date.strftime('%m-%d-%Y')}"
             description = self._get_issue_description(
                 step_name=pair["failure"].step,  # type: ignore
@@ -148,6 +149,7 @@ class Report:
                     labels=labels,
                     affects_version=affects_version,
                     assignee=assignee,
+                    priority=priority,
                 )
                 bugs_filed.append(jira_issue.key)
 

--- a/cli/report/report.py
+++ b/cli/report/report.py
@@ -95,6 +95,7 @@ class Report:
             epic = pair["rule"].jira_epic  # type: ignore
             component = pair["rule"].jira_component  # type: ignore
             affects_version = pair["rule"].jira_affects_version  # type: ignore
+            assignee = pair["rule"].jira_assignee  # type: ignore
             summary = f"Failure in {job.name}, {date.strftime('%m-%d-%Y')}"
             description = self._get_issue_description(
                 step_name=pair["failure"].step,  # type: ignore
@@ -146,6 +147,7 @@ class Report:
                     file_attachments=file_attachments,
                     labels=labels,
                     affects_version=affects_version,
+                    assignee=assignee,
                 )
                 bugs_filed.append(jira_issue.key)
 

--- a/docs/configuration_guide.md
+++ b/docs/configuration_guide.md
@@ -15,6 +15,7 @@
       * [`jira_affects_version`](#jiraaffectsversion)
       * [`jira_additional_labels`](#jiraadditionallabels)
       * [`jira_assignee`](#jiraassignee)
+      * [`jira_priority`](#jirapriority)
       * [`ignore`](#ignore)
 
 ## Jira Issue Creation (`firewatch report`) Configuration
@@ -180,6 +181,30 @@ The email address of the user you would like a bug assigned to if a bug is creat
 **Notes:**
 
 - Must be the EMAIL ADDRESS of the user you would like to assign bugs to.
+
+---
+
+#### `jira_priority`
+
+The priority desired for a bug created using this rule.
+
+**Example(s):**
+
+- `"jira_priority": "Blocker"`
+- `"jira_priority": "critical"`
+- `"jira_priority": "MAJOR"`
+- `"jira_priority": "Normal"`
+- `"jira_priority": "minor"`
+
+**Notes:**
+
+- This value must be set to one of the following, as they are the only available options in Red Hat's Jira instance (may be expanded):
+  - `Blocker`
+  - `Critical`
+  - `Major`
+  - `Normal`
+  - `Minor`
+- This value is _not_ case-sensitive.
 
 ---
 

--- a/docs/configuration_guide.md
+++ b/docs/configuration_guide.md
@@ -14,6 +14,7 @@
       * [`jira_component`](#jiracomponent)
       * [`jira_affects_version`](#jiraaffectsversion)
       * [`jira_additional_labels`](#jiraadditionallabels)
+      * [`jira_assignee`](#jiraassignee)
       * [`ignore`](#ignore)
 
 ## Jira Issue Creation (`firewatch report`) Configuration
@@ -165,6 +166,20 @@ A list of additional labels to add to a bug.
 **Notes:**
 
 - The Jira API will not allow these strings to have spaces in them.
+
+---
+
+#### `jira_assignee`
+
+The email address of the user you would like a bug assigned to if a bug is created.
+
+**Example:**
+
+- `"jira_assignee": "some-user@redhat.com"`
+
+**Notes:**
+
+- Must be the EMAIL ADDRESS of the user you would like to assign bugs to.
 
 ---
 

--- a/tests/unittests/test_firewatch_objects_rule.py
+++ b/tests/unittests/test_firewatch_objects_rule.py
@@ -29,6 +29,7 @@ class TestFirewatchObjectsRule:
             "jira_affects_version": "test version",
             "jira_additional_labels": ["some-label-1", "some-label-2"],
             "jira_assignee": "some-email@redhat.com",
+            "jira_priority": "blocker",
             "ignore": False,
         }
 
@@ -45,6 +46,7 @@ class TestFirewatchObjectsRule:
             "some-label-2" in rule.jira_additional_labels
         )
         assert rule.jira_assignee == "some-email@redhat.com"
+        assert rule.jira_priority == "Blocker"
         assert not rule.ignore
 
     def test_get_step(self) -> None:
@@ -143,6 +145,17 @@ class TestFirewatchObjectsRule:
         test_rule_dict = {"step": "test"}
         jira_assignee = Rule._get_jira_assignee(self, test_rule_dict)
         assert jira_assignee is None
+
+    def test_get_jira_priority(self) -> None:
+        # Test when jira_priority is defined
+        test_rule_dict = {"jira_priority": "major"}
+        jira_priority = Rule._get_jira_priority(self, test_rule_dict)
+        assert jira_priority == "Major"
+
+        # Test when jira_priority is not defined
+        test_rule_dict = {"step": "test"}
+        jira_priority = Rule._get_jira_priority(self, test_rule_dict)
+        assert jira_priority is None
 
     def test_get_ignore(self) -> None:
         # Test when defined as "true"

--- a/tests/unittests/test_firewatch_objects_rule.py
+++ b/tests/unittests/test_firewatch_objects_rule.py
@@ -28,6 +28,7 @@ class TestFirewatchObjectsRule:
             "jira_component": "test component",
             "jira_affects_version": "test version",
             "jira_additional_labels": ["some-label-1", "some-label-2"],
+            "jira_assignee": "some-email@redhat.com",
             "ignore": False,
         }
 
@@ -43,6 +44,7 @@ class TestFirewatchObjectsRule:
         assert ("some-label-1" in rule.jira_additional_labels) and (
             "some-label-2" in rule.jira_additional_labels
         )
+        assert rule.jira_assignee == "some-email@redhat.com"
         assert not rule.ignore
 
     def test_get_step(self) -> None:
@@ -117,6 +119,30 @@ class TestFirewatchObjectsRule:
         test_rule_dict = {"step": "test"}
         jira_affects_version = Rule._get_jira_affects_version(self, test_rule_dict)
         assert jira_affects_version is None
+
+    def test_get_jira_additional_labels(self) -> None:
+        # Test when jira_additional_labels is defined
+        test_rule_dict = {"jira_additional_labels": ["some-label-1", "some-label-2"]}
+        jira_additional_labels = Rule._get_jira_additional_labels(self, test_rule_dict)
+        assert ("some-label-1" in jira_additional_labels) and (
+            "some-label-2" in jira_additional_labels
+        )
+
+        # Test when jira_additional_labels is not defined
+        test_rule_dict = {"step": "test"}
+        jira_additional_labels = Rule._get_jira_additional_labels(self, test_rule_dict)
+        assert jira_additional_labels is None
+
+    def test_get_jira_assignee(self) -> None:
+        # Test when jira_assignee is defined
+        test_rule_dict = {"jira_assignee": "some-email@redhat.com"}
+        jira_assignee = Rule._get_jira_assignee(self, test_rule_dict)
+        assert jira_assignee == "some-email@redhat.com"
+
+        # Test when jira_assignee is not defined
+        test_rule_dict = {"step": "test"}
+        jira_assignee = Rule._get_jira_assignee(self, test_rule_dict)
+        assert jira_assignee is None
 
     def test_get_ignore(self) -> None:
         # Test when defined as "true"


### PR DESCRIPTION
**Modifications**
- **[70081a9](https://github.com/CSPI-QE/firewatch/pull/23/commits/70081a9c967bf6fdfc0324ec21c5775f866da18a)**: Slightly modified the way the firewatch configuration is handled. I noticed that there wasn't any error handling or validation around obtaining the default project or the firewatch config.

**New Features**
- **[fc28391](https://github.com/CSPI-QE/firewatch/pull/23/commits/fc28391df98feee7eef38873f3d6119f839cadf6)**: I have added the new optional field `jira_assignee`. This field allows users to specify which Jira user bugs should be filed under. The value must be the email address of the user they would like to assign bugs to.
- **[b9ffee5](https://github.com/CSPI-QE/firewatch/pull/23/commits/b9ffee5513c7a5acbb57b79c7155776a3291239e)**: I have added the new optional field `jira_priority` This field allows users to specify the priority that bugs should be set to when filed for each rule. This value must be one of the following:
  - `Blocker`
  - `Critical`
  - `Major`
  - `Normal`
  - `Minor`