### PR TITLE
[Maintenance] Update Dockerfile, remove unneeded pre-commit hook, fix logging

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -26,10 +26,6 @@ repos:
   rev: v3.0.1
   hooks:
   - id: add-trailing-comma
-- repo: https://github.com/asottile/setup-cfg-fmt
-  rev: v2.4.0
-  hooks:
-  - id: setup-cfg-fmt
 - repo: https://github.com/pre-commit/mirrors-mypy
   rev: v1.5.1
   hooks:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM docker.io/library/python:3.11
+FROM docker.io/library/python:3.11-slim
 
 COPY pyproject.toml poetry.lock README.md /firewatch/
 COPY cli /firewatch/cli/
@@ -9,7 +9,7 @@ ENV POETRY_HOME=/firewatch
 ENV PATH="/firewatch/bin:$PATH"
 
 RUN python3 -m pip install pip poetry --upgrade \
-    && poetry config cache-dir /openshift-cli-installer \
+    && poetry config cache-dir /firewatch \
     && poetry config virtualenvs.in-project true \
     && poetry config installer.max-workers 10 \
     && poetry install \

--- a/cli/objects/job.py
+++ b/cli/objects/job.py
@@ -142,6 +142,7 @@ class Job:
         Returns:
             str: A string object representing the path that artifacts have been downloaded to.
         """
+        self.logger.info("Downloading JUnit files...")
 
         # Create the junit download directory if it does not exist
         path = f"{downloads_directory}/artifacts"
@@ -178,7 +179,7 @@ class Job:
                 f"{path}/{blob_step}/{blob_name}"
                 with open(file_path, "xb") as target:
                     blob.download_to_file(target)
-                    self.logger.info(f"{file_path} downloaded successfully...")
+                    self.logger.debug(f"{file_path} downloaded successfully...")
 
         return path
 
@@ -205,6 +206,7 @@ class Job:
         Returns:
             str: A string object representing the path to the downloaded logs.
         """
+        self.logger.info("Downloading log files...")
 
         files_to_download = ["finished.json", "build-log.txt"]
 
@@ -231,7 +233,7 @@ class Job:
                 file = f"{path}/{blob_step}/{blob_name}"
                 with open(file, "xb") as target:
                     blob.download_to_file(target)
-                    self.logger.info(f"{file} downloaded successfully...")
+                    self.logger.debug(f"{file} downloaded successfully...")
 
         return path
 


### PR DESCRIPTION
This PR is basically just a few house-keeping items that I noticed needed fixing.

#### Changes

1. Update the base image of the Dockerfile to the `3.11-slim` tag. This dramatically reduces the size of the final image from around 1.13 GB to about 275 MB.
2. Fix the poetry cache directory. It looks like this may have been a copy-and-paste mistake in when switching over to poetry.
3. Remove the unneeded pre-commit hook `setup-cfg-fmt`. This commit was used prior to switching to poetry.
4. Changed the log-level of the `**file** downloaded....` messages to `debug`. These messages seemed excessive and made the logs harder to read. If there is an issue downloading a file, there will be an appropriate error message displayed. 