### PR TITLE
Cleanup jira_config_jen code

### DIFF
--- a/cli/jira_config_gen/__init__.py
+++ b/cli/jira_config_gen/__init__.py
@@ -47,13 +47,12 @@ from cli.jira_config_gen.jira_config_gen import JiraConfig
 @click.command("jira_config_gen")
 @click.pass_context
 def jira_config_gen(
-    ctx: click.Context,
     server_url: str,
     token_path: str,
     output_file: str,
     template_path: str,
 ) -> None:
-    config = JiraConfig(
+    JiraConfig(
         server_url=server_url,
         token_path=token_path,
         output_file=output_file,

--- a/cli/jira_config_gen/__init__.py
+++ b/cli/jira_config_gen/__init__.py
@@ -45,7 +45,6 @@ from cli.jira_config_gen.jira_config_gen import JiraConfig
     type=click.Path(exists=True),
 )
 @click.command("jira_config_gen")
-@click.pass_context
 def jira_config_gen(
     server_url: str,
     token_path: str,

--- a/cli/jira_config_gen/jira_config_gen.py
+++ b/cli/jira_config_gen/jira_config_gen.py
@@ -101,6 +101,6 @@ class JiraConfig:
         with open(output_file, "w") as file:
             file.write(rendered_template)
 
-        self.logger.info(f"Config file written to {output_file}")
+        self.logger.success(f"Config file written to {output_file}")
 
         return output_file

--- a/cli/jira_config_gen/jira_config_gen.py
+++ b/cli/jira_config_gen/jira_config_gen.py
@@ -16,6 +16,7 @@
 #
 from pathlib import Path
 
+import click
 from jinja2 import Environment
 from jinja2 import FileSystemLoader
 from simple_logger.logger import get_logger
@@ -57,8 +58,14 @@ class JiraConfig:
         Returns:
             str: A string object that represents the Jira API token
         """
-        with open(file_path) as file:
-            return file.read().strip()
+        try:
+            with open(file_path) as file:
+                return file.read().strip()
+        except Exception as ex:
+            self.logger.error(
+                f"Failed to read Jira token from {file_path}. error: {ex}",
+            )
+            raise click.Abort()
 
     def render_template(
         self,

--- a/cli/jira_config_gen/jira_config_gen.py
+++ b/cli/jira_config_gen/jira_config_gen.py
@@ -57,15 +57,8 @@ class JiraConfig:
         Returns:
             str: A string object that represents the Jira API token
         """
-        try:
-            with open(file_path) as file:
-                token = file.read().strip()
-                return token
-        except FileNotFoundError:
-            self.logger.error("File not found:", file_path)
-        except OSError as e:
-            self.logger.error("Error reading file:", e)
-        return "token_not_found"
+        with open(file_path) as file:
+            return file.read().strip()
 
     def render_template(
         self,


### PR DESCRIPTION
Remove unused variables.
Remove try:except from `def token`, click check if the file exists and we need to raise if we failed and not return `str` on error.
