### PR TITLE
[Issue #83] Include a list of past bugs of a specific step/failure_type in description of new bugs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 # firewatch
 
-The firewatch project is in its infancy and currently has limited functionality. Ultimately, we'd like this tool to be a way to manage, track, and react to job failures in OpenShift CI.
+Thank you for your interest in the firewatch project! Please find some information about the project below. If you are looking for more information, please see the additional documentation below:
 
-**What may be added in future?**
-
-- Automatic re-tries for user-defined failures in an OpenShift CI job.
+- [CLI Usage Guide](docs/cli_usage_guide.md)
+- [Configuration Guide](docs/configuration_guide.md)
+- [Contribution Guide](docs/CONTRIBUTING.md)
 
 ## Features
 
@@ -14,6 +14,8 @@ The firewatch project is in its infancy and currently has limited functionality.
   - If multiple issues are created for a run, the issues will all be related to each other to help with issue.
   - The issues created have a "classification" section that is defined by the user in their firewatch config.
     - This can be used as a "best-guess" for what may have gone wrong during the job's run.
+  - Firewatch will search for any past issues created by a specific step that has failed in the same way (pod failure or test failure) and list the 10 most recent ones.
+    - This is meant to help the engineer working on the bug to find a solution.
   - Firewatch searches for duplicate issues and makes a comment on the issues rather than filing a second issue.
     - This is done using the labels on issues created by firewatch. These labels should consist of the failure type, failed step, and the job name.
     - If the new failures matches the failure type, failed step, and job name; firewatch will make a comment notifying the user that this failure likely happened again.
@@ -98,7 +100,8 @@ firewatch is released under the [GNU Public License](LICENSE).
 
 If you have any questions, suggestions, or feedback, feel free to reach out to us:
 
-- Project Repository: [https://github.com/CSPI-QE/firewatch](https://github.com/CSPI-QE/firewatch)
-- Issue Tracker: [https://github.com/CSPI-QE/firewatch/issues](https://github.com/CSPI-QE/firewatch/issues)
+- Project Repository: [CSPI-QE/firewatch](https://github.com/CSPI-QE/firewatch)
+- Issue Tracker: [CSPI-QE/firewatch Issues](https://github.com/CSPI-QE/firewatch/issues)
+- Slack: [#ocp-ci-firewatch-tool](https://redhat-internal.slack.com/archives/C062WMK4MCM)
 
 We appreciate your interest in firewatch!

--- a/cli/objects/jira_base.py
+++ b/cli/objects/jira_base.py
@@ -176,7 +176,7 @@ class Jira:
             list[str]: List of issues that are returned from the query.
         """
         issues = []
-        results = self.connection.search_issues(jql_query, validate_query=True)
+        results = self.search(jql_query)
 
         for issue in results:
             issues.append(issue.key)

--- a/cli/objects/jira_base.py
+++ b/cli/objects/jira_base.py
@@ -15,6 +15,7 @@
 #    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
 import json
+from typing import Any
 from typing import Optional
 
 from jira import Issue
@@ -152,9 +153,21 @@ class Jira:
 
         return issue
 
-    def search(self, jql_query: str) -> list[str]:
+    def search(self, jql_query: str) -> list[Any]:
         """
-        Performs a Jira JQL query using the Jira connection and returns the results.
+        Performs a Jira JQL query using the Jira connection and returns a list of issues, including all fields.
+
+        Args:
+            jql_query (str): JQL query to run.
+
+        Returns:
+            list[Any]: List of issues that are returned from the query.
+        """
+        return self.connection.search_issues(jql_query, validate_query=True)
+
+    def search_issues(self, jql_query: str) -> list[str]:
+        """
+        Performs a Jira JQL query using the Jira connection and returns a list of strings representing issue keys.
 
         Args:
             jql_query (str): JQL query to run.

--- a/cli/report/report.py
+++ b/cli/report/report.py
@@ -21,6 +21,7 @@ from datetime import datetime
 from typing import Any
 from typing import Optional
 
+import jira
 from simple_logger.logger import get_logger
 
 from cli.objects.configuration import Configuration
@@ -147,9 +148,11 @@ class Report:
             summary = f"Failure in {job.name}, {date.strftime('%m-%d-%Y')}"
             description = self._get_issue_description(
                 step_name=pair["failure"].step,  # type: ignore
+                failure_type=pair["failure"].failure_type,  # type: ignore
                 classification=pair["rule"].classification,  # type: ignore
                 job_name=job.name,  # type: ignore
                 build_id=job.build_id,  # type: ignore
+                jira=firewatch_config.jira,  # type: ignore
             )
             issue_type = "Bug"
             file_attachments = self._get_file_attachments(
@@ -425,8 +428,10 @@ class Report:
         job_name: str,
         build_id: str,
         step_name: Optional[str] = None,
+        failure_type: Optional[str] = None,
         classification: Optional[str] = None,
         success_issue: Optional[bool] = False,
+        jira: Optional[Jira] = None,
     ) -> str:
         """
         Used to generate the description of a bug to be filed in Jira.
@@ -441,22 +446,30 @@ class Report:
         Returns:
             str: String object representing the description.
         """
-        base_description = f"""
-*Link:* https://prow.ci.openshift.org/view/gs/origin-ci-test/logs/{job_name}/{build_id}
-*Build ID:* {build_id}
-"""
+        link_line = f"*Prow Job Link:* [{job_name} #{build_id}|https://prow.ci.openshift.org/view/gs/origin-ci-test/logs/{job_name}/{build_id}]"
+        build_id_line = f"*Build ID:* {build_id}"
+        firewatch_link_line = f"This {'issue' if success_issue else 'bug'} was filed using [firewatch in OpenShift CI|https://github.com/CSPI-QE/firewatch)]"
+
+        # If the issue is being created for a failure
         if not success_issue:
-            base_description += f"""
-*Classification:* {classification}
-*Failed Step:* {step_name}
+            classification_line = f"*Classification:* {classification}"
+            failed_step_line = f"*Failed Step:* {step_name}"
+            past_bugs = self._get_past_bugs(
+                failed_step=step_name,  # type: ignore
+                failure_type=failure_type,  # type: ignore
+                jira=jira,  # type: ignore
+            )
+            description = f"{link_line}\n{build_id_line}\n{classification_line}\n{failed_step_line}"
+            if past_bugs:
+                description += f"\n----\nHere are up to 10 related bugs produced by the step *{step_name}* and failed with failure type *{failure_type}*:\n{self._get_past_bugs_table(issues=past_bugs, jira=jira)}\n"  # type: ignore
 
-Please see the link provided above along with the logs and junit files attached to the bug.
-"""
-        base_description += f"""
-This {'issue' if success_issue else 'bug'} was filed using [firewatch in OpenShift CI|https://github.com/CSPI-QE/firewatch)]
-"""
+        # If the issue is being created for a success
+        else:
+            description = f"{link_line}\n{build_id_line}"
 
-        return base_description
+        description += f"\n{firewatch_link_line}"
+
+        return description
 
     def _get_issue_labels(
         self,
@@ -521,7 +534,7 @@ This {'issue' if success_issue else 'bug'} was filed using [firewatch in OpenShi
         # AND has a label that matches the failure type
         # AND the bugs are not closed
         jql_query = f'project = {project} AND labels="{job_name}" AND labels="{failed_step}" AND labels="{failure_type}" AND status not in (closed)'
-        duplicate_bugs = jira.search(jql_query=jql_query)
+        duplicate_bugs = jira.search_issues(jql_query=jql_query)
 
         if len(duplicate_bugs) > 0:
             self.logger.info("Possible duplicate bugs found:")
@@ -553,9 +566,9 @@ This {'issue' if success_issue else 'bug'} was filed using [firewatch in OpenShi
         # has a label that matches the job name
         # AND a label that == "firewatch"
         # AND does NOT have a label that == "ignore-passing-notification"
-        # AND a is not in the "closed" status
+        # AND is not in the "closed" status
         jql_query = f'labels="{job_name}" AND labels="firewatch" AND labels!="ignore-passing-notification" AND status not in (closed)'
-        open_bugs = jira.search(jql_query=jql_query)
+        open_bugs = jira.search_issues(jql_query=jql_query)
 
         if len(open_bugs) > 0:
             self.logger.info(f"Found open bugs for job {job_name}:")
@@ -565,3 +578,52 @@ This {'issue' if success_issue else 'bug'} was filed using [firewatch in OpenShi
             return open_bugs
         else:
             return None
+
+    def _get_past_bugs(
+        self,
+        failed_step: str,
+        failure_type: str,
+        jira: Jira,
+    ) -> Optional[list[jira.Issue]]:
+        """
+        Used to search for closed bugs for a specific step and failure type.
+
+        Args:
+            failed_step (str): The name of the failed step to search for bugs under.
+            failure_type (str): The failure type to search for bugs under
+            jira (Jira): Jia object.
+
+        Returns:
+            Optional[list[jira.Issue]]: An optional list of Jira issues from firewatch that are from a specific failed step and failure type.
+        """
+        list_of_issues = jira.search(
+            jql_query=f'labels="{failed_step}" AND labels="{failure_type}" ORDER BY created DESC',
+        )
+
+        # Reduce to 10 most recent issues
+        return list_of_issues[:10]
+
+    def _get_past_bugs_table(self, issues: list[jira.Issue], jira: Jira) -> str:
+        """
+        Used to build the table of bugs related to a specific step/failure type that will be put in issue descriptions
+
+        Args:
+            issues (list[jira.Issue]): A list of jira issues.
+            jira (Jira): Jia object.
+
+        Returns:
+            str: A string object representing the table of related Jira issues to be put in a bug description.
+        """
+        table = "||Bug||Date Created||Assignee||"
+        issue_rows = []
+
+        for issue in issues:
+            date_created = issue.get_field("created").split("T")[0]
+            assignee = issue.get_field("assignee")
+            issue_row = f"\n|[{issue.key}|{jira.url}/browse/{issue.key}]|{date_created}|{assignee}|"
+            issue_rows.append(issue_row)
+
+        for row in issue_rows:
+            table += row
+
+        return table

--- a/cli/report/report.py
+++ b/cli/report/report.py
@@ -597,7 +597,7 @@ class Report:
             Optional[list[jira.Issue]]: An optional list of Jira issues from firewatch that are from a specific failed step and failure type.
         """
         list_of_issues = jira.search(
-            jql_query=f'labels="{failed_step}" AND labels="{failure_type}" ORDER BY created DESC',
+            jql_query=f'labels="{failed_step}" AND labels="{failure_type}" AND status in (closed) ORDER BY created DESC',
         )
 
         # Reduce to 10 most recent issues

--- a/tests/unittests/test_firewatch_report.py
+++ b/tests/unittests/test_firewatch_report.py
@@ -153,33 +153,6 @@ class TestFirewatchReport:
         for file in file_attachments:
             assert os.path.exists(file)
 
-    def test_get_issue_description(self) -> None:
-        step_name = "test-step-name"
-        classification = "test-classification"
-        job_name = "test-job-name"
-        build_id = "12345"
-
-        compare_description = f"""
-*Link:* https://prow.ci.openshift.org/view/gs/origin-ci-test/logs/{job_name}/{build_id}
-*Build ID:* {build_id}
-
-*Classification:* {classification}
-*Failed Step:* {step_name}
-
-Please see the link provided above along with the logs and junit files attached to the bug.
-
-This bug was filed using [firewatch in OpenShift CI|https://github.com/CSPI-QE/firewatch)]
-"""
-        issue_description = Report._get_issue_description(
-            self,
-            step_name=step_name,
-            classification=classification,
-            job_name=job_name,
-            build_id=build_id,
-        )
-
-        assert compare_description == issue_description
-
     def test_filter_priority_rule_failure_pairs_priorities_set(self) -> None:
         # Test when groups/priorities are set
         group_rule_1 = Rule(


### PR DESCRIPTION
This pull request updates the description of new bugs to include a list of up to 10 of the most recent past bugs from a specific step and failure_type. For example, if `step-1` has had a `pod_failure` failure type 5 types in the past and a new bug is being filed, the issue description of the new bug will include a table of those bugs in order of date create. 

Here is an example of the new description in the stage environment:

![Screenshot from 2023-10-30 16-08-35](https://github.com/CSPI-QE/firewatch/assets/44474682/04a4e1e3-57f8-48af-bf80-6188e4b6298f)
