### PR TITLE
[Issue #53] Change Commands and Arguments to Use a Hyphen Rather Than an Underscore

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -10,8 +10,6 @@ repos:
     - id: requirements-txt-fixer
     - id: check-docstring-first
     - id: check-json
-# commenting this check for catalog-info.yaml
-#    - id: check-yaml
 - repo: https://github.com/asottile/reorder-python-imports
   rev: v3.12.0
   hooks:

--- a/cli/jira_config_gen/__init__.py
+++ b/cli/jira_config_gen/__init__.py
@@ -14,37 +14,37 @@
 #    You should have received a copy of the GNU General Public License
 #    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
-"""Module building jira_config_gen cli command"""
+"""Module building jira-config-gen cli command"""
 import click
 
 from cli.jira_config_gen.jira_config_gen import JiraConfig
 
 
 @click.option(
-    "--server_url",
+    "--server-url",
     help='Jira server URL, i.e "https://issues.stage.redhat.com"',
     required=True,
     type=click.STRING,
 )
 @click.option(
-    "--token_path",
+    "--token-path",
     help="Path to the Jira API token",
     required=True,
     type=click.Path(exists=True),
 )
 @click.option(
-    "--output_file",
+    "--output-file",
     help="Where the rendered config will be stored",
     default="/tmp/jira.config",
     type=click.Path(),
 )
 @click.option(
-    "--template_path",
+    "--template-path",
     help="Directory holding templates",
     default="/firewatch/cli/templates/jira.config.j2",
     type=click.Path(exists=True),
 )
-@click.command("jira_config_gen")
+@click.command("jira-config-gen")
 def jira_config_gen(
     server_url: str,
     token_path: str,

--- a/cli/report/__init__.py
+++ b/cli/report/__init__.py
@@ -26,43 +26,43 @@ from cli.report.report import Report
 
 
 @click.option(
-    "--job_name",
+    "--job-name",
     help="The full name of a Prow job. The value of $JOB_NAME",
     required=False,
     type=click.STRING,
 )
 @click.option(
-    "--job_name_safe",
+    "--job-name-safe",
     help="The safe name of a test in a Prow job. The value of $JOB_NAME_SAFE",
     required=False,
     type=click.STRING,
 )
 @click.option(
-    "--build_id",
+    "--build-id",
     help="The build ID that needs to be reported. The value of $BUILD_ID",
     required=False,
     type=click.STRING,
 )
 @click.option(
-    "--gcs_bucket",
+    "--gcs-bucket",
     help="The name of the GCS bucket that holds OpenShift CI logs",
     default="origin-ci-test",
     type=click.STRING,
 )
 @click.option(
-    "--firewatch_config_path",
+    "--firewatch-config-path",
     help="The path to the firewatch configuration file",
     required=False,
     type=click.Path(exists=True),
 )
 @click.option(
-    "--jira_config_path",
+    "--jira-config-path",
     help="The path to the jira configuration file",
     default="/tmp/jira.config",
     type=click.Path(exists=True),
 )
 @click.option(
-    "--fail_with_test_failures",
+    "--fail-with-test-failures",
     help="Firewatch will fail with a non-zero exit code if a test failure is found.",
     is_flag=True,
     default=False,

--- a/cli/report/report.py
+++ b/cli/report/report.py
@@ -98,7 +98,7 @@ class Report:
         # Exit with code 1 if the fail_with_test_failures flag is set.
         if firewatch_config.fail_with_test_failures and job.has_test_failures:
             self.logger.info(
-                "Test failures found and --fail_with_test_failures flag is set. Exiting with exit code 1",
+                "Test failures found and --fail-with-test-failures flag is set. Exiting with exit code 1",
             )
             exit(1)
 

--- a/development/test.sh
+++ b/development/test.sh
@@ -2,7 +2,7 @@
 
 # Build Jira config
 echo "${JIRA_TOKEN}" > /tmp/token
-firewatch jira_config_gen --token_path /tmp/token --server_url "${JIRA_SERVER_URL}"
+firewatch jira-config-gen --token-path /tmp/token --server-url "${JIRA_SERVER_URL}"
 
 # Execute Firewatch
 firewatch report

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -63,7 +63,7 @@ We strive to maintain a friendly and inclusive community. We have not yet establ
     ```
 
 3. Create the Jira config file (execute from the root of the firewatch repository)
-   - `$ echo $JIRA_TOKEN > /tmp/token && poetry run firewatch jira_config_gen --token_path /tmp/token --server_url $JIRA_SERVER --template_path $(pwd)/cli/templates/jira.config.j2`
+   - `$ echo $JIRA_TOKEN > /tmp/token && poetry run firewatch jira-config-gen --token-path /tmp/token --server-url $JIRA_SERVER --template-path $(pwd)/cli/templates/jira.config.j2`
 4. Execute firewatch (execute from the root of the firewatch repository)
    - `$ poetry run firewatch report`
 

--- a/docs/cli_usage_guide.md
+++ b/docs/cli_usage_guide.md
@@ -9,7 +9,7 @@
   * [Configuration](#configuration)
   * [Usage](#usage)
     * [`report`](#report)
-    * [`jira_config_gen`](#jiraconfiggen)
+    * [`jira-config-gen`](#jiraconfiggen)
 
 ## Installation
 
@@ -41,7 +41,7 @@ Many of the arguments for this command have set defaults or will use an environm
 
 **Pre-requisites:**
 
-1. A Jira configuration file must exist. Use the `jira_config_gen` command to generate the configuration file.
+1. A Jira configuration file must exist. Use the `jira-config-gen` command to generate the configuration file.
 2. A firewatch config must be defined. Use the [Configuration section above](#configuration) to generate your configuration.
 
 **Arguments:**
@@ -54,17 +54,17 @@ Options:
                                     directory (/tmp/12345) that is created to hold
                                     logs and results for a job following
                                     execution.
-  --fail_with_test_failures  BOOL   Firewatch will fail with a non-zero exit code
+  --fail-with-test-failures  BOOL   Firewatch will fail with a non-zero exit code
                                     if a test failure is found.
-  --jira_config_path PATH           The path to the jira configuration file
-  --firewatch_config_path PATH      The path to the firewatch configuration file
-  --gcs_bucket TEXT                 The name of the GCS bucket that holds
+  --jira-config-path PATH           The path to the jira configuration file
+  --firewatch-config-path PATH      The path to the firewatch configuration file
+  --gcs-bucket TEXT                 The name of the GCS bucket that holds
                                     OpenShift CI logs
-  --build_id TEXT                   The build ID that needs to be reported. The
+  --build-id TEXT                   The build ID that needs to be reported. The
                                     value of $BUILD_ID
-  --job_name_safe TEXT              The safe name of a test in a Prow job. The
+  --job-name-safe TEXT              The safe name of a test in a Prow job. The
                                     value of $JOB_NAME_SAFE
-  --job_name TEXT                   The full name of a Prow job. The value of
+  --job-name TEXT                   The full name of a Prow job. The value of
                                     $JOB_NAME
   --help                            Show this message and exit.
 ```
@@ -80,10 +80,10 @@ $ export FIREWATCH_CONFIG="[{"step": "some-step-name","failure_type":"pod_failur
 $ firewatch report
 
 # Using CLI arguments
-$ firewatch report --build_id some_build_id --job_name_safe some_safe_job_name --job_name some_job_name --firewatch_config_path /some/path/to/firewatch_config.json
+$ firewatch report --build-id some_build_id --job-name-safe some_safe_job_name --job_name some_job_name --firewatch-config-path /some/path/to/firewatch_config.json
 
 # Exit with a non-zero exit code if test failures are found in any JUnit file for a step
-$ firewatch report --fail_with_test_failures
+$ firewatch report --fail-with-test-failures
 
 # Don't delete the job directory in /tmp (would usually be used for debugging purposes).
 $ firewatch report --keep-job-dir
@@ -142,19 +142,19 @@ If Any issues are found that match all the conditions above, we can be fairly co
 >
 > This comment was created using firewatch in OpenShift CI.
 
-### `jira_config_gen`
+### `jira-config-gen`
 
-The `jira_config_gen` command is used to generate the Jira configuration file used when firewatch interacts with a Jira server.
+The `jira-config-gen` command is used to generate the Jira configuration file used when firewatch interacts with a Jira server.
 
 **Arguments:**
 
 ```commandline
-Usage: firewatch jira_config_gen [OPTIONS]
+Usage: firewatch jira-config-gen [OPTIONS]
 
 Options:
-  --output_file TEXT  Where the rendered config will be stored  [required]
-  --token_path TEXT   Path to the Jira API token  [required]
-  --server_url TEXT   Jira server URL, i.e "https://issues.stage.redhat.com"
+  --output-file TEXT  Where the rendered config will be stored  [required]
+  --token-path TEXT   Path to the Jira API token  [required]
+  --server-url TEXT   Jira server URL, i.e "https://issues.stage.redhat.com"
                       [required]
   --help              Show this message and exit.
 ```
@@ -163,8 +163,8 @@ Options:
 
 ```commandline
 # Create a configuration file in the default location (/tmp/jira.config)
-$ firewatch jira_config_gen --token_path {Path to file containing Jira API token} --server_url https://some.jira.server.com
+$ firewatch jira-config-gen --token-path {Path to file containing Jira API token} --server-url https://some.jira.server.com
 
 # Create a configuration file in a different location (/some/path/jira.config)
-$ firewatch jira_config_gen --token_path {Path to file containing Jira API token} --server_url https://some.jira.server.com --output_file /some/path
+$ firewatch jira-config-gen --token-path {Path to file containing Jira API token} --server-url https://some.jira.server.com --output-file /some/path
 ```

--- a/docs/configuration_guide.md
+++ b/docs/configuration_guide.md
@@ -39,7 +39,7 @@ Firewatch was designed to allow for users to define which Jira issues get create
 ]
 ```
 
-The firewatch configuration can be saved to a file (can be stored wherever you want and named whatever you want, it must be JSON though) or defined in the `FIREWATCH_CONFIG` variable. When using the `report` command, if an argument for `--firewatch_config_path` is not provided, the environment variable will be used.
+The firewatch configuration can be saved to a file (can be stored wherever you want and named whatever you want, it must be JSON though) or defined in the `FIREWATCH_CONFIG` variable. When using the `report` command, if an argument for `--firewatch-config-path` is not provided, the environment variable will be used.
 
 The firewatch configuration is a list of rules, each rule is defined using the following values:
 


### PR DESCRIPTION
This PR will convert all the underscores to hyphens in the commands and arguments to make firewatch more user-friendly in the command line.

> NOTE:
> 
> This change will not affect firewatch in OpenShift CI yet. This is part of some maintence that needs to be done. Once the maintenance is done, I will switch the OpenShift CI from the `release-v1` branch back to the `main` branch.