### PR TITLE
[Issue 52] Force jira_component to be a list of strings

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ Remember, when you are using the `firewatch-report-issues` ref, some variables n
       ```yaml
       FIREWATCH_CONFIG: |
           [
-              {"step": "exact-step-name", "failure_type": "pod_failure", "classification": "Infrastructure", "jira_project": "PROJECT", "jira_component": "some-component", "jira_assignee": "some-user@redhat.com"},
+              {"step": "exact-step-name", "failure_type": "pod_failure", "classification": "Infrastructure", "jira_project": "PROJECT", "jira_component": ["some-component"], "jira_assignee": "some-user@redhat.com"},
               {"step": "*partial-name*", "failure_type": "all", "classification":  "Misc.", "jira_project": "OTHER", "jira_component": ["component-1", "component-2"], "jira_priority": "major", "group": {"name": "some-group", "priority": 1}},
               {"step": "*ends-with-this", "failure_type": "test_failure", "classification": "Test failures", "jira_project": "TEST", "jira_epic": "EPIC-123", "jira_additional_labels": ["test-label-1", "test-label-2"], "group": {"name": "some-group", "priority": 2}},
               {"step": "*ignore*", "failure_type": "test_failure", "classification": "NONE", "jira_project": "NONE", "ignore": "true"},

--- a/cli/objects/rule.py
+++ b/cli/objects/rule.py
@@ -196,10 +196,7 @@ class Rule:
 
         jira_component = rule_dict.get("jira_component")
 
-        if isinstance(jira_component, str):
-            components.append(jira_component)
-            return components
-        elif isinstance(jira_component, list):
+        if isinstance(jira_component, list):
             for component in jira_component:
                 if isinstance(component, str):
                     components.append(component)
@@ -213,7 +210,7 @@ class Rule:
             return jira_component
 
         self.logger.error(
-            f'Value for "jira_component" must be either a list of strings (multiple components) or a string value (single component) in firewatch rule: "{rule_dict}"',
+            f'Value for "jira_component" must be a list of strings (multiple components) in firewatch rule: "{rule_dict}"',
         )
         exit(1)
 

--- a/docs/configuration_guide.md
+++ b/docs/configuration_guide.md
@@ -30,7 +30,7 @@ Firewatch was designed to allow for users to define which Jira issues get create
 
 ```json
 [
-    {"step": "exact-step-name", "failure_type": "pod_failure", "classification": "Infrastructure", "jira_project": "PROJECT", "jira_component": "some-component"},
+    {"step": "exact-step-name", "failure_type": "pod_failure", "classification": "Infrastructure", "jira_project": "PROJECT", "jira_component": ["some-component"]},
     {"step": "*partial-name*", "failure_type": "all", "classification":  "Misc.", "jira_project": "OTHER", "jira_component": ["component-1", "component-2"], "group": {"name": "some-group", "priority": 1}},
     {"step": "*ends-with-this", "failure_type": "test_failure", "classification": "Test failures", "jira_project": "TEST", "jira_epic": "EPIC-123", "jira_additional_labels": ["test-label-1", "test-label-2"], "group": {"name": "some-group", "priority": 2}},
     {"step": "*ignore*", "failure_type": "test_failure", "classification": "NONE", "jira_project": "NONE", "ignore": "true"},
@@ -148,12 +148,10 @@ The epic you would like issues to be related to. This value should just be the I
 
 The component/components you would like issues to be added to.
 
-**Example:**
+**Examples:**
 
-- Using a single component:
-  - `"jira_component": "component-name"`
-- Using multiple components:
-  - `"jira_component": ["component-1", "component-2"]`
+- `"jira_component": ["component-1"]`
+- `"jira_component": ["component-1", "component-2"]`
 
 **Notes:**
 

--- a/tests/unittests/test_firewatch_objects_rule.py
+++ b/tests/unittests/test_firewatch_objects_rule.py
@@ -25,7 +25,7 @@ class TestFirewatchObjectsRule:
             "classification": "test classification",
             "jira_project": "TEST",
             "jira_epic": "TEST-1234",
-            "jira_component": "test component",
+            "jira_component": ["test component"],
             "jira_affects_version": "test version",
             "jira_additional_labels": ["some-label-1", "some-label-2"],
             "jira_assignee": "some-email@redhat.com",
@@ -40,7 +40,7 @@ class TestFirewatchObjectsRule:
         assert rule.classification == test_rule_dict["classification"]
         assert rule.jira_project == test_rule_dict["jira_project"]
         assert rule.jira_epic == test_rule_dict["jira_epic"]
-        assert test_rule_dict["jira_component"] in rule.jira_component
+        assert rule.jira_component == test_rule_dict["jira_component"]
         assert rule.jira_affects_version == test_rule_dict["jira_affects_version"]
         assert ("some-label-1" in rule.jira_additional_labels) and (
             "some-label-2" in rule.jira_additional_labels
@@ -92,13 +92,6 @@ class TestFirewatchObjectsRule:
         assert jira_epic is None
 
     def test_get_jira_component(self) -> None:
-        # Test when single component is defined
-        test_rule_dict = {"jira_component": "test component"}
-        jira_component = Rule._get_jira_component(self, test_rule_dict)
-        assert isinstance(jira_component, list)
-        assert "test component" in jira_component
-
-        # Test when multiple components are defined
         test_rule_dict = {"jira_component": ["test component 1", "test component 2"]}
         jira_component = Rule._get_jira_component(self, test_rule_dict)
         assert isinstance(jira_component, list)


### PR DESCRIPTION
This PR changes the allowed "type" of the `jira_component` value to only be a list of strings to avoid confusion and for consistency. Previously, it allowed a string or a list of strings.

> **NOTE**
> 
> This change will not go into affect in OpenShift CI until the rest of the "release-v2" feature and change requests are complete. 