### PR TITLE
[Issue #100] Move the "report success" functionality configuration to a flag that utilizes `$FIREWATCH_DEFAULT_*` environment variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Thank you for your interest in the firewatch project! Please find some informati
   - If no failures are found, firewatch will search for any open issues on the Jira server provided and add a comment to the issue mentioning that the job has passed since that issue was filed.
     - This functionality also uses the labels on issues created by firewatch.
     - **Note:** If you get a notification on an issue, but would like to continue working on the issue without getting notifications, add the `ignore-passing-notification` label to the issue.
-  - If firewatch config contains job success reporting, a jira will be created (with status `closed`) reporting the job success
+  - An optional Jira story can be created (with status `closed`) reporting the job success by using the `--report-success` option.
 
 ## Getting Started
 
@@ -49,13 +49,15 @@ Remember, when you are using the `firewatch-report-issues` ref, some variables n
           [
               {"step": "exact-step-name", "failure_type": "pod_failure", "classification": "Infrastructure", "jira_project": "PROJECT", "jira_component": ["some-component"], "jira_assignee": "some-user@redhat.com"},
               {"step": "*partial-name*", "failure_type": "all", "classification":  "Misc.", "jira_project": "OTHER", "jira_component": ["component-1", "component-2"], "jira_priority": "major", "group": {"name": "some-group", "priority": 1}},
-              {"step": "*ends-with-this", "failure_type": "test_failure", "classification": "Test failures", "jira_project": "TEST", "jira_epic": "EPIC-123", "jira_additional_labels": ["test-label-1", "test-label-2"], "group": {"name": "some-group", "priority": 2}},
+              {"step": "*ends-with-this", "failure_type": "test_failure", "classification": "Test failures", "jira_project": "TEST", "jira_epic": "!default", "jira_additional_labels": ["test-label-1", "test-label-2"], "group": {"name": "some-group", "priority": 2}},
               {"step": "*ignore*", "failure_type": "test_failure", "classification": "NONE", "jira_project": "NONE", "ignore": "true"},
               {"step": "affects-version", "failure_type": "all", "classification": "Affects Version", "jira_project": "TEST", "jira_epic": "EPIC-123", "jira_affects_version": "4.14"},
-              {"job_success": true, "jira_project": "TEST", "jira_epic": "EPIC-123"}
           ]
       ```
 
+- `FIREWATCH_DEFAULT_JIRA_PROJECT` [REQUIRED]
+  - The default Jira project to report issues to.
+  - Also where success stories are reported.
 - `FIREWATCH_JIRA_SERVER`
   - The Jira server to report to.
   - DEFAULT: `https://issues.stage.redhat.com`
@@ -68,6 +70,10 @@ Remember, when you are using the `firewatch-report-issues` ref, some variables n
   - BEHAVIOR:
     - `"false"`: The `firewatch-report-issues` step will not fail with a non-zero exit code when test failures are found.
     - `"true"`: The `firewatch-report-issues` step will fail with a non-zero exit code when test failures are found.
+
+- `FIREWATCH_DEFAULT_JIRA_EPIC` [OPTIONAL]
+  - The default Jira epic to report issues to where the "jira_epic" value is set to "!default".
+  - Also where success stories are reported.
 
 ### Local Usage
 

--- a/cli/objects/configuration.py
+++ b/cli/objects/configuration.py
@@ -107,7 +107,7 @@ class Configuration:
         Gets the default jira project from the $FIREWATCH_DEFAULT_JIRA_PROJECT environment variable.
 
         Returns:
-            str: The string of the default Jira project environment variable.
+            str: The default Jira project name defined in environment variable.
         """
 
         default_project = os.getenv("FIREWATCH_DEFAULT_JIRA_PROJECT")
@@ -131,7 +131,7 @@ class Configuration:
         Gets the default Jira epic from the $FIREWATCH_DEFAULT_JIRA_EPIC environment variables and validates that it is a string.
 
         Returns:
-            Optional[str]: The string of the default Jira epic environment variable.
+            Optional[str]: The default Jira project name defined in environment variable.
         """
         default_epic = os.getenv("FIREWATCH_DEFAULT_JIRA_EPIC")
 

--- a/cli/objects/configuration.py
+++ b/cli/objects/configuration.py
@@ -31,6 +31,7 @@ class Configuration:
         jira: Jira,
         fail_with_test_failures: bool,
         keep_job_dir: bool,
+        report_success: bool,
         config_file_path: Union[str, None] = None,
     ):
         """
@@ -39,6 +40,8 @@ class Configuration:
         Args:
             jira (Jira): A Jira object used to log in and interact with Jira
             fail_with_test_failures (bool): If a test failure is found, after bugs are filed, firewatch will exit with a non-zero exit code
+            keep_job_dir (bool): If true, firewatch will not delete the job directory (/tmp/12345) that is created to hold logs and results for a job following execution.
+            report_success (bool): If true, firewatch will create a Jira story reporting the success. The story will be closed immediately.
             config_file_path (Union[str, None], optional): The firewatch config can be stored in a file or an environment var. Defaults to None.
         """
         self.logger = get_logger(__name__)
@@ -46,14 +49,18 @@ class Configuration:
         # Jira Connection
         self.jira = jira
 
-        # Check if DEFAULT_JIRA_PROJECT
+        # Get defaults
         self.default_jira_project = self._get_default_jira_project()
+        self.default_jira_epic = self._get_default_jira_epic()
 
         # Boolean value representing if the program should fail if test failures are found.
         self.fail_with_test_failures = fail_with_test_failures
 
         # Boolean value to decide if firewatch should delete the job directory following execution.
         self.keep_job_dir = keep_job_dir
+
+        # Boolean value to decide if firewatch should report a success to Jira
+        self.report_success = report_success
 
         # Get the config data
         self.config_data = self._get_config_data(config_file_path=config_file_path)
@@ -97,21 +104,45 @@ class Configuration:
 
     def _get_default_jira_project(self) -> str:
         """
-        Gets the default jira project from the FIREWATCH_DEFAULT_JIRA_PROJECT environment variable.
+        Gets the default jira project from the $FIREWATCH_DEFAULT_JIRA_PROJECT environment variable.
 
         Returns:
-            str: The string of the default environment variable.
+            str: The string of the default Jira project environment variable.
         """
 
         default_project = os.getenv("FIREWATCH_DEFAULT_JIRA_PROJECT")
 
-        if default_project:
+        # Verify that value is a string if it exists, return
+        if isinstance(default_project, str):
             return default_project
-        else:
+        elif not default_project:
             self.logger.error(
                 "Environment variable $FIREWATCH_DEFAULT_JIRA_PROJECT is not set, please set the variable and try again.",
             )
             exit(1)
+        else:
+            self.logger.error(
+                f'Value for "$FIREWATCH_DEFAULT_JIRA_PROJECT" is not a string: "{default_project}"',
+            )
+            exit(1)
+
+    def _get_default_jira_epic(self) -> Optional[str]:
+        """
+        Gets the default Jira epic from the $FIREWATCH_DEFAULT_JIRA_EPIC environment variables and validates that it is a string.
+
+        Returns:
+            Optional[str]: The string of the default Jira epic environment variable.
+        """
+        default_epic = os.getenv("FIREWATCH_DEFAULT_JIRA_EPIC")
+
+        # Verify that value is a string if it exists, return
+        if isinstance(default_epic, str) or not default_epic:
+            return default_epic
+
+        self.logger.error(
+            f'Value for "$FIREWATCH_DEFAULT_JIRA_EPIC" is not a string: "{default_epic}"',
+        )
+        exit(1)
 
     def _get_config_data(self, config_file_path: Optional[str]) -> str:
         """

--- a/cli/objects/jira_base.py
+++ b/cli/objects/jira_base.py
@@ -148,7 +148,7 @@ class Jira:
             self.connection.transition_issue(
                 issue=issue.key,
                 transition="closed",
-                comment="closed by firewatch",
+                comment="Closed by firewatch.",
             )
 
         return issue

--- a/cli/objects/rule.py
+++ b/cli/objects/rule.py
@@ -14,6 +14,7 @@
 #    You should have received a copy of the GNU General Public License
 #    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
+import os
 import re
 from typing import Any
 from typing import Optional
@@ -33,21 +34,19 @@ class Rule:
         self.logger = get_logger(__name__)
 
         # Build the rule using the rule_dict
-        self.job_success = self._get_success_rule(rule_dict)
+        self.step = self._get_step(rule_dict)
+        self.failure_type = self._get_failure_type(rule_dict)
+        self.classification = self._get_classification(rule_dict)
         self.jira_project = self._get_jira_project(rule_dict)
         self.jira_epic = self._get_jira_epic(rule_dict)
-        if "job_success" not in rule_dict:
-            self.step = self._get_step(rule_dict)
-            self.failure_type = self._get_failure_type(rule_dict)
-            self.classification = self._get_classification(rule_dict)
-            self.jira_component = self._get_jira_component(rule_dict)
-            self.jira_affects_version = self._get_jira_affects_version(rule_dict)
-            self.jira_additional_labels = self._get_jira_additional_labels(rule_dict)
-            self.jira_assignee = self._get_jira_assignee(rule_dict)
-            self.jira_priority = self._get_jira_priority(rule_dict)
-            self.group_name = self._get_group_name(rule_dict)
-            self.group_priority = self._get_group_priority(rule_dict)
-            self.ignore = self._get_ignore(rule_dict)
+        self.jira_component = self._get_jira_component(rule_dict)
+        self.jira_affects_version = self._get_jira_affects_version(rule_dict)
+        self.jira_additional_labels = self._get_jira_additional_labels(rule_dict)
+        self.jira_assignee = self._get_jira_assignee(rule_dict)
+        self.jira_priority = self._get_jira_priority(rule_dict)
+        self.group_name = self._get_group_name(rule_dict)
+        self.group_priority = self._get_group_priority(rule_dict)
+        self.ignore = self._get_ignore(rule_dict)
 
     def _get_step(self, rule_dict: dict[Any, Any]) -> str:
         """
@@ -175,10 +174,12 @@ class Rule:
         jira_epic = rule_dict.get("jira_epic")
 
         if isinstance(jira_epic, str) or not jira_epic:
+            if jira_epic == "!default":
+                return os.getenv("FIREWATCH_DEFAULT_JIRA_EPIC")
             return jira_epic
 
         self.logger.error(
-            f'Value for "jira_epic" is not a string in firewatch rule: "{rule_dict}"',
+            f'Value for "jira_epic" or $FIREWATCH_DEFAULT_JIRA_EPIC is not a string in firewatch rule: "{rule_dict}"',
         )
         exit(1)
 
@@ -396,26 +397,5 @@ class Rule:
 
         self.logger.error(
             f'Value for "ignore" is not a boolean or string value in firewatch rule: "{rule_dict}"',
-        )
-        exit(1)
-
-    def _get_success_rule(self, rule_dict: dict[Any, Any]) -> bool:
-        """
-        Get success rule
-
-        Args:
-            rule_dict (dict[Any, Any]): A dictionary object representing a user-defined firewatch rule.
-
-        Returns:
-            bool: A boolean value that determines if a jira ticket will be opened (with `status: closed`) for success job
-        """
-
-        job_success = rule_dict.get("job_success", False)
-
-        if isinstance(job_success, bool):
-            return job_success
-
-        self.logger.error(
-            f'Value for "job_success" is not a boolean: "{rule_dict}"',
         )
         exit(1)

--- a/cli/report/__init__.py
+++ b/cli/report/__init__.py
@@ -75,6 +75,13 @@ from cli.report.report import Report
     default=False,
     type=click.BOOL,
 )
+@click.option(
+    "--report-success",
+    help="If set, firewatch will create a Jira story in the default Jira project and default Jira epic reporting the success. The story will be closed immediately.",
+    is_flag=True,
+    default=False,
+    type=click.BOOL,
+)
 @click.command("report")
 @click.pass_context
 def report(
@@ -87,6 +94,7 @@ def report(
     jira_config_path: str,
     fail_with_test_failures: bool,
     keep_job_dir: bool,
+    report_success: bool,
 ) -> None:
     # Build Objects
     jira_connection = Jira(jira_config_path=jira_config_path)
@@ -94,6 +102,7 @@ def report(
         jira=jira_connection,
         fail_with_test_failures=fail_with_test_failures,
         keep_job_dir=keep_job_dir,
+        report_success=report_success,
         config_file_path=firewatch_config_path,
     )
     job = Job(

--- a/docs/cli_usage_guide.md
+++ b/docs/cli_usage_guide.md
@@ -50,23 +50,27 @@ Many of the arguments for this command have set defaults or will use an environm
 Usage: firewatch report [OPTIONS]
 
 Options:
-   --keep-job-dir  BOOL             If set, firewatch will not delete the job
-                                    directory (/tmp/12345) that is created to hold
-                                    logs and results for a job following
-                                    execution.
-  --fail-with-test-failures  BOOL   Firewatch will fail with a non-zero exit code
-                                    if a test failure is found.
-  --jira-config-path PATH           The path to the jira configuration file
-  --firewatch-config-path PATH      The path to the firewatch configuration file
-  --gcs-bucket TEXT                 The name of the GCS bucket that holds
-                                    OpenShift CI logs
-  --build-id TEXT                   The build ID that needs to be reported. The
-                                    value of $BUILD_ID
-  --job-name-safe TEXT              The safe name of a test in a Prow job. The
-                                    value of $JOB_NAME_SAFE
-  --job-name TEXT                   The full name of a Prow job. The value of
-                                    $JOB_NAME
-  --help                            Show this message and exit.
+  --report-success              If set, firewatch will create a Jira story in
+                                the default Jira project and default Jira epic
+                                reporting the success. The story will be
+                                closed immediately.
+  --keep-job-dir                If set, firewatch will not delete the job
+                                directory (/tmp/12345) that is created to hold
+                                logs and results for a job following
+                                execution.
+  --fail-with-test-failures     Firewatch will fail with a non-zero exit code
+                                if a test failure is found.
+  --jira-config-path PATH       The path to the jira configuration file
+  --firewatch-config-path PATH  The path to the firewatch configuration file
+  --gcs-bucket TEXT             The name of the GCS bucket that holds
+                                OpenShift CI logs
+  --build-id TEXT               The build ID that needs to be reported. The
+                                value of $BUILD_ID
+  --job-name-safe TEXT          The safe name of a test in a Prow job. The
+                                value of $JOB_NAME_SAFE
+  --job-name TEXT               The full name of a Prow job. The value of
+                                $JOB_NAME
+  --help                        Show this message and exit.
 ```
 
 **Examples:**
@@ -76,6 +80,9 @@ Options:
 $ export BUILD_ID="some_build_id"
 $ export JOB_NAME_SAFE="some_safe_job_name"
 $ export JOB_NAME="some_job_name"
+$ export FIREWATCH_DEFAULT_JIRA_PROJECT="PROJECT"
+# $FIREWATCH_DEFAULT_JIRA_EPIC is optional
+$ export FIREWATCH_DEFAULT_JIRA_EPIC="PROJECT-123
 $ export FIREWATCH_CONFIG="[{"step": "some-step-name","failure_type":"pod_failure", "classification": "some best guess classification", "jira_project": "PROJECT"}]"
 $ firewatch report
 
@@ -87,6 +94,9 @@ $ firewatch report --fail-with-test-failures
 
 # Don't delete the job directory in /tmp (would usually be used for debugging purposes).
 $ firewatch report --keep-job-dir
+
+# Report a success story to Jira. The story will be created in the $FIREWATCH_DEFAULT_JIRA_PROJECT project and in the $FIREWATCH_DEFAULT_JIRA_EPIC epic
+$ firewatch report --report-success
 
 ```
 

--- a/docs/cli_usage_guide.md
+++ b/docs/cli_usage_guide.md
@@ -82,7 +82,7 @@ $ export JOB_NAME_SAFE="some_safe_job_name"
 $ export JOB_NAME="some_job_name"
 $ export FIREWATCH_DEFAULT_JIRA_PROJECT="PROJECT"
 # $FIREWATCH_DEFAULT_JIRA_EPIC is optional
-$ export FIREWATCH_DEFAULT_JIRA_EPIC="PROJECT-123
+$ export FIREWATCH_DEFAULT_JIRA_EPIC="PROJECT-123"
 $ export FIREWATCH_CONFIG="[{"step": "some-step-name","failure_type":"pod_failure", "classification": "some best guess classification", "jira_project": "PROJECT"}]"
 $ firewatch report
 

--- a/docs/configuration_guide.md
+++ b/docs/configuration_guide.md
@@ -4,14 +4,11 @@
 
 * [Configuring Firewatch](#configuring-firewatch)
   * [Jira Issue Creation (`firewatch report`) Configuration](#jira-issue-creation-firewatch-report-configuration)
-    * [Job Required Values](#job-required-values)
+    * [Required Values](#required-values)
       * [`jira_project`](#jiraproject)
-    * [Failed Job Required Values](#failed-job-required-values)
       * [`step`](#step)
       * [`failure_type`](#failuretype)
       * [`classification`](#classification)
-    * [Success Job Required Values](#success-job-required-values)
-      * [`job_success`](#jobsuccess)
     * [Optional Values](#optional-values)
       * [`jira_epic`](#jiraepic)
       * [`jira_component`](#jiracomponent)
@@ -24,7 +21,7 @@
 
 ## Jira Issue Creation (`firewatch report`) Configuration
 
-Firewatch was designed to allow for users to define which Jira issues get created depending on which failures are found in a OpenShift CI failed run or report job success. Using an easy-to-define JSON config, users can easily track issues in their OpenShift CI runs efficiently.
+Firewatch was designed to allow for users to define which Jira issues get created depending on which failures are found in a OpenShift CI failed run. Using an easy-to-define JSON config, users can easily track issues in their OpenShift CI runs efficiently.
 
 **Example:**
 
@@ -35,7 +32,6 @@ Firewatch was designed to allow for users to define which Jira issues get create
     {"step": "*ends-with-this", "failure_type": "test_failure", "classification": "Test failures", "jira_project": "TEST", "jira_epic": "EPIC-123", "jira_additional_labels": ["test-label-1", "test-label-2"], "group": {"name": "some-group", "priority": 2}},
     {"step": "*ignore*", "failure_type": "test_failure", "classification": "NONE", "jira_project": "NONE", "ignore": "true"},
     {"step": "affects-version", "failure_type": "all", "classification": "Affects Version", "jira_project": "TEST", "jira_epic": "EPIC-123", "jira_affects_version": "4.14"},
-    {"job_success": true, "jira_project": "TEST", "jira_epic": "EPIC-123"}
 ]
 ```
 
@@ -43,7 +39,7 @@ The firewatch configuration can be saved to a file (can be stored wherever you w
 
 The firewatch configuration is a list of rules, each rule is defined using the following values:
 
-### Job Required Values
+### Required Values
 
 #### `jira_project`
 
@@ -54,8 +50,6 @@ The Jira project you'd like the issue to be filed under. This should just be a s
 - `"jira_project": "LPTOCPCI"`
 
 ---
-
-### Failed Job Required Values
 
 #### `step`
 
@@ -114,18 +108,6 @@ This can be any string value and does not affect the way issues are created apar
 
 ---
 
-### Success Job Required Values
-
-#### `job_success`
-
-Boolean indicating whether a (status `closed`) jira will be opened for a successful job run.
-
-**Example:**
-
-- `"job_success": true`
-
----
-
 ### Optional Values
 
 #### `jira_epic`
@@ -156,7 +138,6 @@ The component/components you would like issues to be added to.
 **Notes:**
 
 - Please verify the component(s) you are planning on using exist in the project defined in the [`jira_project`](#jiraproject) config value.
-- Does not apply to `job_success`
 
 ---
 
@@ -171,7 +152,6 @@ The version affected by this bug. This will result in the "Affects Version/s" fi
 **Notes:**
 
 - The version must exist in the project defined in the [`jira_project`](#jiraproject) config value.
-- Does not apply to `job_success`
 
 ---
 
@@ -186,7 +166,6 @@ A list of additional labels to add to a bug.
 **Notes:**
 
 - The Jira API will not allow these strings to have spaces in them.
-- Does not apply to `job_success`
 
 ---
 
@@ -197,7 +176,6 @@ The email address of the user you would like a bug assigned to if a bug is creat
 **Example:**
 
 - `"jira_assignee": "some-user@redhat.com"`
-- Does not apply to `job_success`
 
 **Notes:**
 
@@ -226,7 +204,6 @@ The priority desired for a bug created using this rule.
   - `Normal`
   - `Minor`
 - This value is _not_ case-sensitive.
-- Does not apply to `job_success`
 
 ---
 
@@ -241,10 +218,6 @@ A value that be set to "true" or "false" and allows the user to define `step`/`f
 - `"ignore": "false"`
   - Do not ignore the `step`/`failure_type` combination when a failure is found that matches this rule.
   - This is the default behavior of all rules. If set to `false`, it does not need to be defined.
-
-**Notes:**
-
-- Does not apply to `job_success`
 
 #### `group`
 
@@ -272,7 +245,3 @@ Using the example configuration above:
 - If `step-1` fails causing `step-2` and `step-3` to fail, only the rule for `step-1` will be reported because it has the highest priority.
 - If `step-2` fails causing `step-3` to fail, only the rule for `step-2` will be reported because it has the highest priority.
 - If `step-3` fails, only the rule for `step-3` will be reported.
-
-**Notes:**
-
-- Does not apply to `job_success`

--- a/tests/unittests/test_firewatch_report.py
+++ b/tests/unittests/test_firewatch_report.py
@@ -228,16 +228,3 @@ class TestFirewatchReport:
         )
 
         assert filtered_rule_failure_pairs == original_rule_failure_pairs
-
-    def test_success_job_rule(self) -> None:
-        # Test when success job is set
-        rule_1 = Rule(
-            rule_dict={
-                "job_success": True,
-                "jira_project": "NONE",
-            },
-        )
-
-        assert rule_1.job_success, "Rule `job_success` is not set to True"
-
-        assert not hasattr(rule_1, "step"), "Rule has `step` attribute"


### PR DESCRIPTION
This PR will migrate the "report success" functionality from PR #77 out of the firewatch config rules and into a CLI flag (`--report-success`) that makes use of the `$FIREWATCH_DEFAULT_*` environment variables. 

I have done this promote uniform rules in the firewatch config. Considering this functionality is set at the job level rather than on a per step/failure-type basis, I feel it is more suited to a CLI flag.

### How to use:

1. Set the following environment variables (and all other config values that are normally set):
  - `FIREWATCH_DEFAULT_JIRA_PROJECT` [REQUIRED]: This value should already be set anyway, it is not a new piece of the functionality. This is the Jira project where the story will be created
  - `FIREWATCH_DEFAULT_JIRA_EPIC` [OPTIONAL]: This is an optional environment variable that can be set. If it is set, the story will be linked to that Epic. If it is unset, the story will not be associated with an Epic.
2. Execute `firewatch report --report-success`

### `$FIREWATCH_DEFAULT_JIRA_EPIC`

This is the first of a few new `$FIREWATCH_DEFAULT_*` optional environment variables that will be able to be utilized in firewatch rule sets. If set, not only will it affect where the success story is reported (if that functionality is used), but it will allow you to specify `"jira_epic": "!default"` in your rules. Using this value in a rule will cause firewatch to report any issue created for that rule to the `$FIREWATCH_DEFAULT_JIRA_EPIC` epic.

I have only included this variable in this PR as it pertains the to work item I am completing with this PR. The other optional default variables will come in a later PR attached to Issue #25.

> **NOTE**
> 
> This change will not go into affect in OpenShift CI until the rest of the "release-v2" feature and change requests are complete. 