### PR TITLE
[Urgent Change] Update the default gcs bucket to test-platform-results per DPTPs change.

### DIFF
--- a/cli/report/__init__.py
+++ b/cli/report/__init__.py
@@ -66,7 +66,7 @@ def validate_verbose_test_failure_reporting_ticket_limit(
 @click.option(
     "--gcs-bucket",
     help="The name of the GCS bucket that holds OpenShift CI logs",
-    default="origin-ci-test",
+    default="test-platform-results",
     type=click.STRING,
 )
 @click.option(

--- a/cli/report/report.py
+++ b/cli/report/report.py
@@ -361,7 +361,7 @@ class Report:
 
                                 This job has been run successfully since this bug was filed. Please verify that this bug is still relevant and close it if needed.
 
-                                *Passing Run Link:* https://prow.ci.openshift.org/view/gs/test-platform-results /logs/{job.name}/{job.build_id}
+                                *Passing Run Link:* https://prow.ci.openshift.org/view/gs/test-platform-results/logs/{job.name}/{job.build_id}
                                 *Passing Run Build ID:* {job.build_id}
 
 
@@ -397,7 +397,7 @@ class Report:
         comment = f"""
                         A duplicate failure was identified in a recent run of the {job.name} job:
 
-                        *Link:* https://prow.ci.openshift.org/view/gs/test-platform-results /logs/{job.name}/{job.build_id}
+                        *Link:* https://prow.ci.openshift.org/view/gs/test-platform-results/logs/{job.name}/{job.build_id}
                         *Build ID:* {job.build_id}
                         *Classification:* {classification}
                         *Failed Step:* {failed_step}
@@ -509,7 +509,7 @@ class Report:
         Returns:
             str: String object representing the description.
         """
-        link_line = f"*Prow Job Link:* [{job_name} #{build_id}|https://prow.ci.openshift.org/view/gs/test-platform-results /logs/{job_name}/{build_id}]"
+        link_line = f"*Prow Job Link:* [{job_name} #{build_id}|https://prow.ci.openshift.org/view/gs/test-platform-results/logs/{job_name}/{build_id}]"
         build_id_line = f"*Build ID:* {build_id}"
         firewatch_link_line = f"This {'issue' if success_issue else 'bug'} was filed using [firewatch in OpenShift CI|https://github.com/CSPI-QE/firewatch)]"
 

--- a/cli/report/report.py
+++ b/cli/report/report.py
@@ -361,7 +361,7 @@ class Report:
 
                                 This job has been run successfully since this bug was filed. Please verify that this bug is still relevant and close it if needed.
 
-                                *Passing Run Link:* https://prow.ci.openshift.org/view/gs/origin-ci-test/logs/{job.name}/{job.build_id}
+                                *Passing Run Link:* https://prow.ci.openshift.org/view/gs/test-platform-results /logs/{job.name}/{job.build_id}
                                 *Passing Run Build ID:* {job.build_id}
 
 
@@ -397,7 +397,7 @@ class Report:
         comment = f"""
                         A duplicate failure was identified in a recent run of the {job.name} job:
 
-                        *Link:* https://prow.ci.openshift.org/view/gs/origin-ci-test/logs/{job.name}/{job.build_id}
+                        *Link:* https://prow.ci.openshift.org/view/gs/test-platform-results /logs/{job.name}/{job.build_id}
                         *Build ID:* {job.build_id}
                         *Classification:* {classification}
                         *Failed Step:* {failed_step}
@@ -509,7 +509,7 @@ class Report:
         Returns:
             str: String object representing the description.
         """
-        link_line = f"*Prow Job Link:* [{job_name} #{build_id}|https://prow.ci.openshift.org/view/gs/origin-ci-test/logs/{job_name}/{build_id}]"
+        link_line = f"*Prow Job Link:* [{job_name} #{build_id}|https://prow.ci.openshift.org/view/gs/test-platform-results /logs/{job_name}/{build_id}]"
         build_id_line = f"*Build ID:* {build_id}"
         firewatch_link_line = f"This {'issue' if success_issue else 'bug'} was filed using [firewatch in OpenShift CI|https://github.com/CSPI-QE/firewatch)]"
 

--- a/docs/contribution_guide.md
+++ b/docs/contribution_guide.md
@@ -37,7 +37,7 @@ We strive to maintain a friendly and inclusive community. We have not yet establ
 ### Container
 
    1. Find a failed prow job you would like to test against.
-      - **Example**: [periodic-ci-openshift-pipelines-release-tests-release-v1.11-openshift-pipelines-ocp4.14-lp-interop-openshift-pipelines-interop-aws #1696039978221441024](https://prow.ci.openshift.org/view/gs/test-platform-results /logs/periodic-ci-openshift-pipelines-release-tests-release-v1.11-openshift-pipelines-ocp4.14-lp-interop-openshift-pipelines-interop-aws/1696039978221441024)
+      - **Example**: [periodic-ci-openshift-pipelines-release-tests-release-v1.11-openshift-pipelines-ocp4.14-lp-interop-openshift-pipelines-interop-aws #1696039978221441024](https://prow.ci.openshift.org/view/gs/test-platform-results/logs/periodic-ci-openshift-pipelines-release-tests-release-v1.11-openshift-pipelines-ocp4.14-lp-interop-openshift-pipelines-interop-aws/1696039978221441024)
    2. Fill out `firewatch/development/env.list`
       - Use the ["Defining Environment Variables"](#defining-environment-variables) section to help
    3. From the root of this repository, run `make container-build-test` to execute `firewatch report` using the values provided above.
@@ -48,7 +48,7 @@ We strive to maintain a friendly and inclusive community. We have not yet establ
 1. Create your development environment if you haven't already (execute from the root of the firewatch repository):
     - `$ make dev-environment`
 2. Find a failed prow job you would like to test against.
-      - **Example**: [periodic-ci-openshift-pipelines-release-tests-release-v1.11-openshift-pipelines-ocp4.14-lp-interop-openshift-pipelines-interop-aws #1696039978221441024](https://prow.ci.openshift.org/view/gs/test-platform-results /logs/periodic-ci-openshift-pipelines-release-tests-release-v1.11-openshift-pipelines-ocp4.14-lp-interop-openshift-pipelines-interop-aws/1696039978221441024)
+      - **Example**: [periodic-ci-openshift-pipelines-release-tests-release-v1.11-openshift-pipelines-ocp4.14-lp-interop-openshift-pipelines-interop-aws #1696039978221441024](https://prow.ci.openshift.org/view/gs/test-platform-results/logs/periodic-ci-openshift-pipelines-release-tests-release-v1.11-openshift-pipelines-ocp4.14-lp-interop-openshift-pipelines-interop-aws/1696039978221441024)
 2. Export the required environment varaibles:
    - Use the ["Defining Environment Variables"](#defining-environment-variables) section to help
 

--- a/docs/contribution_guide.md
+++ b/docs/contribution_guide.md
@@ -37,7 +37,7 @@ We strive to maintain a friendly and inclusive community. We have not yet establ
 ### Container
 
    1. Find a failed prow job you would like to test against.
-      - **Example**: [periodic-ci-openshift-pipelines-release-tests-release-v1.11-openshift-pipelines-ocp4.14-lp-interop-openshift-pipelines-interop-aws #1696039978221441024](https://prow.ci.openshift.org/view/gs/origin-ci-test/logs/periodic-ci-openshift-pipelines-release-tests-release-v1.11-openshift-pipelines-ocp4.14-lp-interop-openshift-pipelines-interop-aws/1696039978221441024)
+      - **Example**: [periodic-ci-openshift-pipelines-release-tests-release-v1.11-openshift-pipelines-ocp4.14-lp-interop-openshift-pipelines-interop-aws #1696039978221441024](https://prow.ci.openshift.org/view/gs/test-platform-results /logs/periodic-ci-openshift-pipelines-release-tests-release-v1.11-openshift-pipelines-ocp4.14-lp-interop-openshift-pipelines-interop-aws/1696039978221441024)
    2. Fill out `firewatch/development/env.list`
       - Use the ["Defining Environment Variables"](#defining-environment-variables) section to help
    3. From the root of this repository, run `make container-build-test` to execute `firewatch report` using the values provided above.
@@ -48,7 +48,7 @@ We strive to maintain a friendly and inclusive community. We have not yet establ
 1. Create your development environment if you haven't already (execute from the root of the firewatch repository):
     - `$ make dev-environment`
 2. Find a failed prow job you would like to test against.
-      - **Example**: [periodic-ci-openshift-pipelines-release-tests-release-v1.11-openshift-pipelines-ocp4.14-lp-interop-openshift-pipelines-interop-aws #1696039978221441024](https://prow.ci.openshift.org/view/gs/origin-ci-test/logs/periodic-ci-openshift-pipelines-release-tests-release-v1.11-openshift-pipelines-ocp4.14-lp-interop-openshift-pipelines-interop-aws/1696039978221441024)
+      - **Example**: [periodic-ci-openshift-pipelines-release-tests-release-v1.11-openshift-pipelines-ocp4.14-lp-interop-openshift-pipelines-interop-aws #1696039978221441024](https://prow.ci.openshift.org/view/gs/test-platform-results /logs/periodic-ci-openshift-pipelines-release-tests-release-v1.11-openshift-pipelines-ocp4.14-lp-interop-openshift-pipelines-interop-aws/1696039978221441024)
 2. Export the required environment varaibles:
    - Use the ["Defining Environment Variables"](#defining-environment-variables) section to help
 


### PR DESCRIPTION
The DPTP team is moving all artifacts to the test-platform-results GCS bucket. This is happening today, this PR should be merged following the completion of the task.

DPTP comms about this change: https://redhat-internal.slack.com/archives/CFUGK0K9R/p1704920416570079 