### PR TITLE
Handle Jira HTTP 415 after migration to Atlassian Cloud

### DIFF
--- a/src/objects/jira_base.py
+++ b/src/objects/jira_base.py
@@ -384,10 +384,19 @@ class Jira:
             Issue: A Jira Issue object.
         """
         issue = self.get_issue_by_id_or_key(issue_id_or_key)
+        payload = {"update": {"labels": [{"add": label} for label in labels]}}
         try:
-            issue.update(update={"labels": [{"add": label} for label in labels]})
-
-        # Check if the error is a 400 code and potentially due to user permissions.
+            response = self.connection._session.put(
+                issue.self,
+                data=json.dumps(payload),
+                headers={"Content-Type": "application/json"},
+            )
+            if not response.ok:
+                raise JIRAError(
+                    response.status_code,
+                    response.text,
+                    response.url,
+                )
         except JIRAError as error:
             if error.status_code == 400:
                 LOGGER.error(

--- a/src/objects/jira_base.py
+++ b/src/objects/jira_base.py
@@ -385,6 +385,10 @@ class Jira:
         """
         issue = self.get_issue_by_id_or_key(issue_id_or_key)
         payload = {"update": {"labels": [{"add": label} for label in labels]}}
+        # Workaround: use the session PUT with explicit Content-Type because the python-jira
+        # library's issue.update() does not set Content-Type: application/json on the request.
+        # Jira Cloud rejects that with HTTP 415. Prefer self.connection.* elsewhere; this is
+        # the only call that bypasses the library until pycontribs/jira fixes the header.
         try:
             response = self.connection._session.put(
                 issue.self,

--- a/tests/unittests/conftest.py
+++ b/tests/unittests/conftest.py
@@ -525,7 +525,11 @@ def patch_jira_api_requests(
         ):
             data = json.loads(data)
             _json = fake_issue_json.copy()
-            _json["fields"].update(data["fields"])
+            # REST API v3 label update uses {"update": {"labels": [{"add": "..."}]}}
+            if "update" in data:
+                pass  # Accept label/field updates; return success
+            elif "fields" in data:
+                _json["fields"].update(data["fields"])
             return MockJiraApiResponse(_json=_json, _status_code=204)
         else:
             LOGGER.info(f"Unpatched PUT request to: {url}")

--- a/tests/unittests/objects/jira/test_jira.py
+++ b/tests/unittests/objects/jira/test_jira.py
@@ -33,6 +33,19 @@ class TestJiraApiRespondsWithSuccess:
         assert isinstance(issue, Issue)
         assert issue.id == fake_issue_id
 
+    def test_add_labels_to_issue_sends_content_type_json_for_cloud_compatibility(
+        self, fake_issue_id, jira, patch_jira_api_requests
+    ):
+        """Adding labels uses PUT with Content-Type: application/json to avoid 415 from Jira Cloud."""
+        labels = ["retrigger", "firewatch"]
+        result = jira.add_labels_to_issue(issue_id_or_key=fake_issue_id, labels=labels)
+        assert result is not None
+        assert len(patch_jira_api_requests["put"]) == 1
+        _url, (data, args, kwargs) = next(iter(patch_jira_api_requests["put"].items()))
+        assert kwargs.get("headers", {}).get("Content-Type") == "application/json"
+        payload = json.loads(data)
+        assert payload == {"update": {"labels": [{"add": "retrigger"}, {"add": "firewatch"}]}}
+
 
 class TestJiraApiRespondsWithPermissionFailure:
     @pytest.fixture


### PR DESCRIPTION
**Description:**

Following the migration to Atlassian Cloud, firewatch crashes with an `'HTTP 415 Unsupported Media Type'` error when attempting to append labels (like retrigger) to existing Jira issues([example logs](https://gcsweb-ci.apps.ci.l2s4.p1.openshiftapps.com/gcs/test-platform-results/logs/periodic-ci-stackrox-stackrox-release-4.9-ocp-4-21-lp-interop-cr-acs-tests-aws/2034102782012690432/artifacts/acs-tests-aws/firewatch-report-issues/build-log.txt)). This occurs because the jira Python library's `update()` method fails to explicitly set the Content-Type header, which Atlassian Cloud now strictly enforces.

**Solution:**

Bypassed the `issue.update()` wrapper in `add_labels_to_issue`

Replaced it with a direct PUT request via the authenticated session` (self.connection._session.put)`, explicitly passing `headers={"Content-Type": "application/json"}`.