### PR TITLE
INTEROP-8970: Jira Cloud REST v3 ADF across issues, comments, and transitions

### DIFF
--- a/src/escalation/jira_escalation.py
+++ b/src/escalation/jira_escalation.py
@@ -2,6 +2,12 @@ from datetime import timezone, datetime
 import re
 from typing import Optional
 from jira import Issue
+from src.objects.jira_adf import adf_doc
+from src.objects.jira_adf import adf_mention
+from src.objects.jira_adf import description_to_plain_text_for_search
+from src.objects.jira_adf import inline_text
+from src.objects.jira_adf import paragraph
+from src.objects.jira_adf import plain_text_to_adf_doc
 from src.objects.jira_base import Jira
 from src.objects.slack_base import SlackClient
 from simple_logger.logger import get_logger
@@ -137,8 +143,9 @@ class Jira_Escalation:
                 LOGGER.info(f"last updated change date: {last_updated_time}")
 
             days_since_update = (current_time - last_updated_time).days
-            prow_job_name = self.extract_prow_job_name(jira_issue.fields.description)
-            prow_job_url = self.extract_prow_job_link(jira_issue.fields.description)
+            desc_text = description_to_plain_text_for_search(jira_issue.fields.description)
+            prow_job_name = self.extract_prow_job_name(desc_text)
+            prow_job_url = self.extract_prow_job_link(desc_text)
             issue_url = f"<{self.base_issue_url}/browse/{jira_issue.key}|{jira_issue.key}>"
 
             # check if issue is updated within corresponding escalation periods and send relevant notifications
@@ -217,6 +224,8 @@ class Jira_Escalation:
         Returns:
           Optional[str]: prow job url string extracted if found else None
         """
+        if not isinstance(jira_description_text, str):
+            raise TypeError("description must be str; use description_to_plain_text_for_search for ADF")
         try:
             url_pattern = r"https://prow\.ci\.openshift\.org/\S+"
             match = re.search(url_pattern, jira_description_text)
@@ -235,6 +244,8 @@ class Jira_Escalation:
           Optional[str]: prow job name string extracted if found else None
         """
 
+        if not isinstance(jira_description_text, str):
+            raise TypeError("description must be str; use description_to_plain_text_for_search for ADF")
         try:
             pattern = r"periodic-ci-[^\|]+"
             match = re.search(pattern, jira_description_text)
@@ -348,6 +359,15 @@ class Jira_Escalation:
                 f"\n 1 or more days since last comment, please add comment if there is any updates on the issue: {jira_issue.key}"
             )
             assignee_account_id = self.get_user_account_id(jira_issue.fields.assignee)
-            comment = f"[~accountId:{assignee_account_id}], please provide update for this issue."
-            LOGGER.info(f"escalation comment: {comment}")
-            self.jira.comment(jira_issue, comment)
+            comment_body = (
+                adf_doc(
+                    paragraph(
+                        adf_mention(assignee_account_id, "@"),
+                        inline_text(", please provide update for this issue."),
+                    ),
+                )
+                if assignee_account_id
+                else plain_text_to_adf_doc("Please provide update for this issue.")
+            )
+            LOGGER.info("escalation comment prepared for %s", jira_issue.key)
+            self.jira.comment(issue_id=jira_issue.key, comment=comment_body)

--- a/src/objects/jira_adf.py
+++ b/src/objects/jira_adf.py
@@ -1,0 +1,145 @@
+from __future__ import annotations
+
+import copy
+from typing import Any
+
+_BLOCK_TYPES_WITH_INLINE_CONTENT = frozenset({"paragraph", "heading"})
+
+
+def _sanitize_text_node(node: dict[str, Any]) -> dict[str, Any]:
+    text = node.get("text")
+    if isinstance(text, str):
+        text = text.replace("\x00", "")
+    if text is None or text == "":
+        text = " "
+    node = {**node, "text": text}
+    marks = node.get("marks")
+    if not isinstance(marks, list):
+        return node
+    kept: list[dict[str, Any]] = []
+    for m in marks:
+        if m.get("type") == "link":
+            href = (m.get("attrs") or {}).get("href")
+            if not href:
+                continue
+        kept.append(m)
+    if not kept:
+        return {k: v for k, v in node.items() if k != "marks"}
+    return {**node, "marks": kept}
+
+
+def _walk_adf_node(node: dict[str, Any]) -> dict[str, Any]:
+    if node.get("type") == "text":
+        return _sanitize_text_node(node)
+    content = node.get("content")
+    if isinstance(content, list):
+        new_children = [_walk_adf_node(c) if isinstance(c, dict) else c for c in content]
+        ntype = node.get("type")
+        if ntype in _BLOCK_TYPES_WITH_INLINE_CONTENT and len(new_children) == 0:
+            new_children = [{"type": "text", "text": " "}]
+        node = {**node, "content": new_children}
+    return node
+
+
+def sanitize_jira_adf_doc(doc: dict[str, Any]) -> dict[str, Any]:
+    return _walk_adf_node(copy.deepcopy(doc))
+
+
+def plain_text_to_adf_doc(plain: str) -> dict[str, Any]:
+    return {
+        "type": "doc",
+        "version": 1,
+        "content": [
+            {
+                "type": "paragraph",
+                "content": [{"type": "text", "text": plain}],
+            }
+        ],
+    }
+
+
+def adf_doc(*blocks: dict[str, Any]) -> dict[str, Any]:
+    return {"type": "doc", "version": 1, "content": list(blocks)}
+
+
+def paragraph(*inline_nodes: dict[str, Any]) -> dict[str, Any]:
+    return {"type": "paragraph", "content": list(inline_nodes)}
+
+
+def heading(level: int, *inline_nodes: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "type": "heading",
+        "attrs": {"level": level},
+        "content": list(inline_nodes),
+    }
+
+
+def inline_text(
+    text: str,
+    *,
+    bold: bool = False,
+    italic: bool = False,
+    url: str | None = None,
+) -> dict[str, Any]:
+    node: dict[str, Any] = {"type": "text", "text": text}
+    marks: list[dict[str, Any]] = []
+    if bold:
+        marks.append({"type": "strong"})
+    if italic:
+        marks.append({"type": "em"})
+    if url:
+        marks.append({"type": "link", "attrs": {"href": url}})
+    if marks:
+        node["marks"] = marks
+    return node
+
+
+def adf_mention(account_id: str, display_stub: str) -> dict[str, Any]:
+    return {
+        "type": "mention",
+        "attrs": {
+            "id": account_id,
+            "text": display_stub,
+        },
+    }
+
+
+def closed_by_firewatch_adf() -> dict[str, Any]:
+    return adf_doc(
+        paragraph(
+            inline_text("Closed by "),
+            inline_text(
+                "firewatch",
+                url="https://github.com/CSPI-QE/firewatch",
+            ),
+            inline_text("."),
+        ),
+    )
+
+
+def _adf_node_plain_text(node: dict[str, Any]) -> str:
+    t = node.get("type")
+    if t == "text":
+        return str(node.get("text", ""))
+    if t == "mention":
+        return str(node.get("attrs", {}).get("text", ""))
+    if t == "hardBreak":
+        return "\n"
+    parts = node.get("content")
+    if isinstance(parts, list):
+        return "".join(_adf_node_plain_text(c) for c in parts if isinstance(c, dict))
+    return ""
+
+
+def description_to_plain_text_for_search(description: str | dict[str, Any] | None) -> str:
+    if description is None:
+        return ""
+    if isinstance(description, str):
+        return description
+    if isinstance(description, dict) and description.get("type") == "doc":
+        return "".join(
+            _adf_node_plain_text(block) for block in description.get("content", []) if isinstance(block, dict)
+        )
+    if isinstance(description, dict):
+        return _adf_node_plain_text(description)
+    return ""

--- a/src/objects/jira_base.py
+++ b/src/objects/jira_base.py
@@ -8,6 +8,10 @@ from jira.exceptions import JIRAError
 from pyhelper_utils.general import ignore_exceptions
 from simple_logger.logger import get_logger
 
+from src.objects.jira_adf import closed_by_firewatch_adf
+from src.objects.jira_adf import plain_text_to_adf_doc
+from src.objects.jira_adf import sanitize_jira_adf_doc
+
 LOGGER = get_logger(name=__name__)
 
 
@@ -88,7 +92,7 @@ class Jira:
         issue_dict = {
             "project": {"key": project},
             "summary": summary,
-            "description": description,
+            "description": sanitize_jira_adf_doc(plain_text_to_adf_doc(description)),
             "issuetype": {"name": issue_type},
         }
 
@@ -147,10 +151,10 @@ class Jira:
             LOGGER.info(f"Issue {issue} has been assigned to user {assignee}")
 
         if close_issue:
-            self.connection.transition_issue(
-                issue=issue.key,
-                transition="closed",
-                comment="Closed by [firewatch|https://github.com/CSPI-QE/firewatch].",
+            self._transition_issue_with_adf_comment(
+                issue_key=issue.key,
+                transition_name="closed",
+                adf_body=closed_by_firewatch_adf(),
             )
 
         return issue
@@ -212,16 +216,61 @@ class Jira:
 
         return issues
 
+    def _post_issue_comment_adf(self, issue_key: str, adf_body: dict[str, Any]) -> None:
+        url = self.connection._get_url(f"issue/{issue_key}/comment")
+        response = self.connection._session.post(
+            url,
+            json={"body": sanitize_jira_adf_doc(adf_body)},
+            headers={"Content-Type": "application/json"},
+        )
+        if not response.ok:
+            raise JIRAError(
+                text=response.text,
+                status_code=response.status_code,
+                url=response.url,
+            )
+
+    def _transition_issue_with_adf_comment(
+        self,
+        issue_key: str,
+        transition_name: str,
+        adf_body: dict[str, Any],
+    ) -> None:
+        transition_id = self.connection.find_transitionid_by_name(issue_key, transition_name)
+        if transition_id is None:
+            raise JIRAError(
+                text=f"Invalid transition name. {transition_name}",
+                status_code=400,
+                url="",
+            )
+        payload: dict[str, Any] = {
+            "transition": {"id": transition_id},
+            "update": {"comment": [{"add": {"body": sanitize_jira_adf_doc(adf_body)}}]},
+        }
+        url = self.connection._get_url(f"issue/{issue_key}/transitions")
+        response = self.connection._session.post(
+            url,
+            json=payload,
+            headers={"Content-Type": "application/json"},
+        )
+        if not response.ok:
+            raise JIRAError(
+                text=response.text,
+                status_code=response.status_code,
+                url=response.url,
+            )
+
     @ignore_exceptions(retry=3, retry_interval=1, raise_final_exception=True, logger=LOGGER)
-    def comment(self, issue_id: str, comment: str) -> None:
+    def comment(self, issue_id: str, comment: str | dict[str, Any]) -> None:
         """
         Comments on the issue_id.
 
         Args:
             issue_id (str): Issue to comment on.
-            comment (str): Comment to add to issue.
+            comment (str | dict): Plain text (stored as minimal ADF) or an ADF doc dict for the body.
         """
-        self.connection.add_comment(issue_id, comment)
+        body = plain_text_to_adf_doc(comment) if isinstance(comment, str) else comment
+        self._post_issue_comment_adf(issue_id, body)
 
     @ignore_exceptions(retry=3, retry_interval=1, raise_final_exception=True, logger=LOGGER)
     def relate_issues(self, inward_issue: str, outward_issue: str) -> bool:
@@ -262,10 +311,10 @@ class Jira:
             issue = self.get_issue_by_id_or_key(issue_id)
             self.logger.info("Closing issue %s with transition 'closed'...", issue_id)
 
-            self.connection.transition_issue(
-                issue=issue.key,
-                transition="closed",
-                comment="Closed by [firewatch|https://github.com/CSPI-QE/firewatch].",
+            self._transition_issue_with_adf_comment(
+                issue_key=issue.key,
+                transition_name="closed",
+                adf_body=closed_by_firewatch_adf(),
             )
 
             self.logger.info("Issue %s has been successfully closed.", issue_id)
@@ -392,7 +441,7 @@ class Jira:
         try:
             response = self.connection._session.put(
                 issue.self,
-                data=json.dumps(payload),
+                json=payload,
                 headers={"Content-Type": "application/json"},
             )
             if not response.ok:
@@ -402,16 +451,15 @@ class Jira:
                     response.url,
                 )
         except JIRAError as error:
-            if error.status_code == 400:
-                LOGGER.error(
-                    f"Failed to add labels {labels} to issue {issue_id_or_key}. Error: {error.text}",
-                )
+            LOGGER.error(
+                f"Failed to add labels {labels} to issue {issue_id_or_key}. Error: {error.text}",
+            )
+            if error.status_code == 403:
                 LOGGER.info(
-                    "This error could be caused by missing permissions on the Jira user."
-                    'Please see the "Jira User Permissions" section in the README for more information.',
+                    "This error can be caused by missing permissions on the Jira user."
+                    ' Please see the "Jira User Permissions" section in the README for more information.',
                 )
-            else:
-                raise
+            raise
         return issue
 
     @ignore_exceptions(retry=3, retry_interval=1, raise_final_exception=True, logger=LOGGER)

--- a/src/report/report.py
+++ b/src/report/report.py
@@ -11,6 +11,10 @@ from simple_logger.logger import get_logger
 from src.objects.configuration import Configuration
 from src.objects.failure import Failure
 from src.objects.failure_rule import FailureRule
+from src.objects.jira_adf import adf_doc
+from src.objects.jira_adf import heading
+from src.objects.jira_adf import inline_text
+from src.objects.jira_adf import paragraph
 from src.objects.jira_base import Jira
 from src.objects.job import Job
 from src.report.constants import JOB_PASSED_SINCE_TICKET_CREATED_LABEL, JOB_RETRIGGERED_IN_CURRENT_WEEK_LABEL
@@ -375,20 +379,38 @@ class Report:
         Returns:
             None
         """
-        comment = f"""
-                                h4. *JOB RECENTLY PASSED*
-
-                                This job has been run successfully since this bug was filed. Please verify that this bug is still relevant and close it if needed.
-
-                                *Passing Run Link:* https://prow.ci.openshift.org/view/gs/test-platform-results/logs/{job.name}/{job.build_id}
-                                *Passing Run Build ID:* {job.build_id}
-
-
-                                _Please add the "ignore-passing-notification" tag to this bug to avoid future passing job notifications._
-
-                                This comment was created using [firewatch in OpenShift CI|https://github.com/CSPI-QE/firewatch].
-                            """
-        jira.comment(issue_id=issue_id, comment=comment)
+        prow_url = f"https://prow.ci.openshift.org/view/gs/test-platform-results/logs/{job.name}/{job.build_id}"
+        fw_url = "https://github.com/CSPI-QE/firewatch"
+        body = adf_doc(
+            heading(4, inline_text("JOB RECENTLY PASSED", bold=True)),
+            paragraph(
+                inline_text(
+                    "This job has been run successfully since this bug was filed. "
+                    "Please verify that this bug is still relevant and close it if needed.",
+                ),
+            ),
+            paragraph(
+                inline_text("Passing Run Link: ", bold=True),
+                inline_text(prow_url, url=prow_url),
+            ),
+            paragraph(
+                inline_text("Passing Run Build ID: ", bold=True),
+                inline_text(job.build_id or ""),
+            ),
+            paragraph(
+                inline_text(
+                    'Please add the "ignore-passing-notification" label to this bug to avoid future '
+                    "passing job notifications.",
+                    italic=True,
+                ),
+            ),
+            paragraph(
+                inline_text("This comment was created using "),
+                inline_text("firewatch in OpenShift CI", url=fw_url),
+                inline_text("."),
+            ),
+        )
+        jira.comment(issue_id=issue_id, comment=body)
 
     def add_passing_job_label(self, jira: Jira, issue_id: str) -> None:
         """
@@ -445,21 +467,54 @@ class Report:
         Returns:
             None
         """
-        comment = f"""
-                        A duplicate failure was identified in a recent run of the {job.name} job:
-
-                        *Link:* https://prow.ci.openshift.org/view/gs/test-platform-results/logs/{job.name}/{job.build_id}
-                        *Build ID:* {job.build_id}
-                        *Classification:* {classification}
-                        *Failed Step:* {failed_step}
-                        {"*Failed Test:* " + failed_test_name if failed_test_name else ""}
-
-                        Please see the link provided above to determine if this is the same issue. If it is not, please manually file a new bug for this issue.
-
-                        This comment was created using [firewatch in OpenShift CI|https://github.com/CSPI-QE/firewatch]
-                    """
-
-        jira.comment(issue_id=issue_id, comment=comment)
+        link = f"https://prow.ci.openshift.org/view/gs/test-platform-results/logs/{job.name}/{job.build_id}"
+        fw_url = "https://github.com/CSPI-QE/firewatch"
+        blocks: list[dict[str, Any]] = [
+            paragraph(
+                inline_text(
+                    f"A duplicate failure was identified in a recent run of the {job.name} job:",
+                ),
+            ),
+            paragraph(
+                inline_text("Link: ", bold=True),
+                inline_text(link, url=link),
+            ),
+            paragraph(
+                inline_text("Build ID: ", bold=True),
+                inline_text(job.build_id or ""),
+            ),
+            paragraph(
+                inline_text("Classification: ", bold=True),
+                inline_text(classification),
+            ),
+            paragraph(
+                inline_text("Failed Step: ", bold=True),
+                inline_text(failed_step),
+            ),
+        ]
+        if failed_test_name:
+            blocks.append(
+                paragraph(
+                    inline_text("Failed Test: ", bold=True),
+                    inline_text(failed_test_name),
+                ),
+            )
+        blocks.extend(
+            [
+                paragraph(
+                    inline_text(
+                        "Please see the link provided above to determine if this is the same issue. "
+                        "If it is not, please manually file a new bug for this issue.",
+                    ),
+                ),
+                paragraph(
+                    inline_text("This comment was created using "),
+                    inline_text("firewatch in OpenShift CI", url=fw_url),
+                    inline_text("."),
+                ),
+            ],
+        )
+        jira.comment(issue_id=issue_id, comment=adf_doc(*blocks))
 
     def relate_issues(self, issues: list[str], jira: Jira) -> None:
         """

--- a/tests/unittests/conftest.py
+++ b/tests/unittests/conftest.py
@@ -488,6 +488,12 @@ def patch_jira_api_requests(
         elif url.endswith("/search") or "/search/jql" in url:
             LOGGER.info("Faking Jira search results")
             return MockJiraApiResponse(_json=fake_search_response_json, _status_code=200)
+        elif url_contains_fake_issue_id_or_key(url) and "/transitions" in url:
+            LOGGER.info("Faking Jira transitions list")
+            return MockJiraApiResponse(
+                _json={"transitions": [{"id": 5, "name": "closed"}]},
+                _status_code=200,
+            )
         elif url_ends_with_fake_issue_id_or_key(url) and url_contains_issue_subpath(url):
             LOGGER.info(f"Faking Jira issue: {url}")
             return MockJiraApiResponse(_json=fake_issue_json, _status_code=200)
@@ -506,6 +512,8 @@ def patch_jira_api_requests(
                 _json=fake_comment_response_json,
                 _status_code=201,
             )
+        elif url_contains_fake_issue_id_or_key(url) and "/transitions" in url:
+            return MockJiraApiResponse(_content=b"{}", _status_code=200)
         elif url_contains_fake_issue_id_or_key(url) and url_contains_issue_subpath and url.endswith("/attachments"):
             LOGGER.info(f"Faking Jira file upload: {url}")
             return fake_issue_add_attachment_response
@@ -514,7 +522,7 @@ def patch_jira_api_requests(
             monkeypatch.undo()
             return requests.sessions.Session.post(self=self, url=url, *args, **kwargs)
 
-    def put(self, url, data, *args, **kwargs):
+    def put(self, url, data=None, *args, **kwargs):
         LOGGER.info(f"Patching PUT request to URL: {url}")
         caps["put"][url] = (data, args, kwargs)
 
@@ -523,18 +531,20 @@ def patch_jira_api_requests(
             and url_ends_with_fake_issue_id_or_key(url)
             and url_contains_issue_subpath(url)
         ):
-            data = json.loads(data)
+            if data is not None:
+                body = json.loads(data) if isinstance(data, (str, bytes)) else data
+            else:
+                body = kwargs.get("json") or {}
             _json = fake_issue_json.copy()
-            # REST API v3 label update uses {"update": {"labels": [{"add": "..."}]}}
-            if "update" in data:
-                pass  # Accept label/field updates; return success
-            elif "fields" in data:
-                _json["fields"].update(data["fields"])
+            if "update" in body:
+                pass
+            elif "fields" in body:
+                _json["fields"].update(body["fields"])
             return MockJiraApiResponse(_json=_json, _status_code=204)
         else:
             LOGGER.info(f"Unpatched PUT request to: {url}")
             monkeypatch.undo()
-            return requests.sessions.Session.put(self, url, *args, **kwargs)
+            return requests.sessions.Session.put(self, url, data=data, *args, **kwargs)
 
     monkeypatch.setattr(requests.sessions.Session, "get", get)
     monkeypatch.setattr(requests.sessions.Session, "post", post)

--- a/tests/unittests/functions/escalation/test_jira_escalation.py
+++ b/tests/unittests/functions/escalation/test_jira_escalation.py
@@ -1,7 +1,7 @@
 import pytest
 
 from unittest.mock import MagicMock, patch
-from src.escalation.jira_escalation import Jira_Escalation
+from src.escalation.jira_escalation import Jira_Escalation, description_to_plain_text_for_search
 from datetime import datetime, timedelta, timezone
 
 from simple_logger.logger import get_logger
@@ -11,6 +11,51 @@ LOGGER = get_logger(name=__name__)
 
 
 FIXED_NOW = datetime(2025, 5, 1, tzinfo=timezone.utc)
+
+PROW_WIKI_LINE = "* Prow Job Link *: [periodic-ci-test-job-name #11234567|https://prow.ci.openshift.org/some/log/path]"
+
+PROW_DESCRIPTION_ADF = {
+    "type": "doc",
+    "version": 1,
+    "content": [
+        {
+            "type": "heading",
+            "attrs": {"level": 4},
+            "content": [{"type": "text", "text": "Job"}],
+        },
+        {
+            "type": "paragraph",
+            "content": [
+                {"type": "text", "text": PROW_WIKI_LINE},
+            ],
+        },
+    ],
+}
+
+
+class TestDescriptionToPlainTextForSearch:
+    def test_passes_through_plain_string(self):
+        assert description_to_plain_text_for_search(PROW_WIKI_LINE) == PROW_WIKI_LINE
+
+    def test_flattens_adf_doc_to_searchable_text(self):
+        flat = description_to_plain_text_for_search(PROW_DESCRIPTION_ADF)
+        assert PROW_WIKI_LINE in flat
+        assert "periodic-ci-test-job-name" in flat
+        assert "https://prow.ci.openshift.org/some/log/path" in flat
+
+    def test_extract_prow_job_name_after_flattening_adf_description(self):
+        flat = description_to_plain_text_for_search(PROW_DESCRIPTION_ADF)
+        assert Jira_Escalation.extract_prow_job_name(flat) == "periodic-ci-test-job-name #11234567"
+
+    def test_extract_prow_job_link_after_flattening_adf_description(self):
+        flat = description_to_plain_text_for_search(PROW_DESCRIPTION_ADF)
+        assert Jira_Escalation.extract_prow_job_link(flat) == "https://prow.ci.openshift.org/some/log/path"
+
+    def test_extractors_fail_on_raw_adf_dict_without_flattening(self):
+        with pytest.raises(TypeError):
+            Jira_Escalation.extract_prow_job_name(PROW_DESCRIPTION_ADF)
+        with pytest.raises(TypeError):
+            Jira_Escalation.extract_prow_job_link(PROW_DESCRIPTION_ADF)
 
 
 @pytest.fixture
@@ -219,9 +264,12 @@ def test_process_issues(
 
     elif expect_add_jira_comment:
         mock_jira.comment.assert_called_once()
-        args, kwargs = mock_jira.comment.call_args
-        # Comment should use accountId mention format for Jira Cloud compatibility
-        assert "[~accountId:" in args[1]
+        kwargs = mock_jira.comment.call_args.kwargs
+        comment = kwargs["comment"]
+        assert isinstance(comment, dict)
+        mention = comment["content"][0]["content"][0]
+        assert mention["type"] == "mention"
+        assert mention["attrs"]["id"] == f"accountId:{assignee_email}"
 
     elif expect_notify_assignee_in_slack:
         escalation.send_slack_notification.assert_called_once()

--- a/tests/unittests/functions/report/test_firewatch_functions_report_add_label_to_ticket_when_job_run_passes.py
+++ b/tests/unittests/functions/report/test_firewatch_functions_report_add_label_to_ticket_when_job_run_passes.py
@@ -1,3 +1,5 @@
+import json
+
 import pytest
 import simple_logger.logger
 from jira import Issue
@@ -65,10 +67,15 @@ def test_report_adds_passing_label_to_newly_passing_job_with_open_bugs(
     fake_issue_id,
 ):
     Report(firewatch_config=firewatch_config, job=job)
-    put_request_data_to_issue_endpoint = [
-        v[0]
-        for k, v in patch_jira_api_requests["put"].items()
-        if k.endswith(f"/issue/{fake_issue_id}") or k.endswith(f"/issue/{fake_issue_key}")
-    ]
+    put_request_data_to_issue_endpoint = []
+    for k, v in patch_jira_api_requests["put"].items():
+        if k.endswith(f"/issue/{fake_issue_id}") or k.endswith(f"/issue/{fake_issue_key}"):
+            data, _args, kwargs = v
+            if data is not None:
+                put_request_data_to_issue_endpoint.append(
+                    data if isinstance(data, str) else json.dumps(data),
+                )
+            else:
+                put_request_data_to_issue_endpoint.append(json.dumps(kwargs.get("json") or {}))
     exp = '"update": {"labels": [{"add": "' + JOB_PASSED_SINCE_TICKET_CREATED_LABEL + '"}]'
-    assert any([exp in _ for _ in put_request_data_to_issue_endpoint])
+    assert any(exp in _ for _ in put_request_data_to_issue_endpoint)

--- a/tests/unittests/objects/jira/test_firewatch_objects_jira_base_close_issue.py
+++ b/tests/unittests/objects/jira/test_firewatch_objects_jira_base_close_issue.py
@@ -1,8 +1,19 @@
+import logging
+
 import pytest
 from unittest.mock import MagicMock
 from jira.exceptions import JIRAError
 from pytest import MonkeyPatch
 from src.objects.jira_base import Jira
+
+from tests.unittests.objects.jira.test_jira import _assert_adf_doc
+from tests.unittests.objects.jira.test_jira import _post_request_json
+
+
+@pytest.fixture
+def jira(patch_jira_api_requests, jira, caplog):
+    jira.logger.handlers[0] = caplog.handler
+    yield jira
 
 
 @pytest.fixture
@@ -22,33 +33,21 @@ def mock_jira(monkeypatch: MonkeyPatch):
     return jira
 
 
-def test_close_issue_success(mock_jira: Jira):
-    """
-    Tests the successful execution path of close_issue.
-    """
-    issue_id = "TEST-123"
-    mock_issue = MagicMock()
-    mock_issue.key = issue_id
-    mock_jira.get_issue_by_id_or_key.return_value = mock_issue
-
-    # Call the method
-    mock_jira.close_issue(issue_id)
-
-    # Assert
-    # 1. Verify the method calls
-    mock_jira.get_issue_by_id_or_key.assert_called_once_with(issue_id)
-    mock_jira.connection.transition_issue.assert_called_once_with(
-        issue=issue_id,
-        transition="closed",
-        comment="Closed by [firewatch|https://github.com/CSPI-QE/firewatch].",
+def test_close_issue_success(patch_jira_api_requests, fake_issue_key, jira: Jira, caplog):
+    with caplog.at_level(logging.INFO, logger="src.objects.jira_base"):
+        jira.close_issue(fake_issue_key)
+    transition_urls = [u for u in patch_jira_api_requests["post"] if "/transitions" in u]
+    assert len(transition_urls) == 1
+    _args, kwargs = patch_jira_api_requests["post"][transition_urls[0]]
+    payload = _post_request_json(kwargs)
+    assert "update" in payload
+    comment_body = payload["update"]["comment"][0]["add"]["body"]
+    assert not isinstance(comment_body, str), (
+        "Jira Cloud REST v3 expects transition comment body as ADF, not a plain string"
     )
-
-    # 2. Verify ALL expected logs were made
-    mock_jira.logger.info.assert_any_call("Closing issue %s with transition 'closed'...", issue_id)
-    mock_jira.logger.info.assert_any_call("Issue %s has been successfully closed.", issue_id)
-
-    # 3. Verify no errors were logged
-    mock_jira.logger.error.assert_not_called()
+    _assert_adf_doc(comment_body)
+    assert "Closing issue" in caplog.text
+    assert "successfully closed" in caplog.text
 
 
 def test_close_issue_jira_error(mock_jira: Jira):
@@ -62,7 +61,8 @@ def test_close_issue_jira_error(mock_jira: Jira):
     mock_jira.get_issue_by_id_or_key.return_value = mock_issue
 
     error = JIRAError(status_code=400, text=error_text)
-    mock_jira.connection.transition_issue.side_effect = error
+    mock_jira.connection.find_transitionid_by_name.return_value = 5
+    mock_jira.connection._session.post.side_effect = error
 
     # Call method
     mock_jira.close_issue(issue_id)
@@ -84,7 +84,8 @@ def test_close_issue_unexpected_exception(mock_jira: Jira):
 
     # The actual exception object is what gets logged
     exception_object = Exception("Unexpected failure")
-    mock_jira.connection.transition_issue.side_effect = exception_object
+    mock_jira.connection.find_transitionid_by_name.return_value = 5
+    mock_jira.connection._session.post.side_effect = exception_object
 
     # Call method
     mock_jira.close_issue(issue_id)

--- a/tests/unittests/objects/jira/test_jira.py
+++ b/tests/unittests/objects/jira/test_jira.py
@@ -38,13 +38,17 @@ class TestJiraApiRespondsWithSuccess:
     ):
         """Adding labels uses PUT with Content-Type: application/json to avoid 415 from Jira Cloud."""
         labels = ["retrigger", "firewatch"]
+        expected = {"update": {"labels": [{"add": "retrigger"}, {"add": "firewatch"}]}}
         result = jira.add_labels_to_issue(issue_id_or_key=fake_issue_id, labels=labels)
         assert result is not None
         assert len(patch_jira_api_requests["put"]) == 1
         _url, (data, args, kwargs) = next(iter(patch_jira_api_requests["put"].items()))
         assert kwargs.get("headers", {}).get("Content-Type") == "application/json"
-        payload = json.loads(data)
-        assert payload == {"update": {"labels": [{"add": "retrigger"}, {"add": "firewatch"}]}}
+        assert kwargs.get("json") == expected
+        assert data is None
+        payload = kwargs["json"]
+        assert "fields" not in payload
+        assert payload == expected
 
 
 class TestJiraApiRespondsWithPermissionFailure:
@@ -63,6 +67,56 @@ class TestJiraApiRespondsWithPermissionFailure:
             attachment_path=fake_attachment_path.as_posix(),
         )
         assert "You do not have permission to create attachments for this issue" in caplog.text
+
+
+def _minimal_adf_doc(plain_text: str) -> dict:
+    return {
+        "type": "doc",
+        "version": 1,
+        "content": [
+            {
+                "type": "paragraph",
+                "content": [{"type": "text", "text": plain_text}],
+            }
+        ],
+    }
+
+
+class TestCreateIssueAdfDescription:
+    @pytest.fixture
+    def mock_jira(self, monkeypatch):
+        monkeypatch.setattr(Jira, "__init__", lambda self, jira_config_path=None: None)
+        jira = Jira()
+        jira.url = DEFAULT_JIRA_SERVER_URL
+        jira.connection = MagicMock()
+
+        created_issue = MagicMock()
+        created_issue.key = "TEST-1"
+        jira.connection.create_issue.return_value = created_issue
+
+        return jira
+
+    def test_create_issue_passes_adf_description_for_jira_cloud_rest_v3(self, mock_jira):
+        plain = "Line one\nLine two"
+        mock_jira.create_issue(
+            project="TEST",
+            summary="Summary",
+            description=plain,
+            issue_type="Bug",
+        )
+        mock_jira.connection.create_issue.assert_called_once()
+        fields = mock_jira.connection.create_issue.call_args[0][0]
+        assert fields["description"] == _minimal_adf_doc(plain)
+
+    def test_create_issue_sanitizes_empty_description_text_node(self, mock_jira):
+        mock_jira.create_issue(
+            project="TEST",
+            summary="Summary",
+            description="",
+            issue_type="Bug",
+        )
+        fields = mock_jira.connection.create_issue.call_args[0][0]
+        assert fields["description"]["content"][0]["content"][0]["text"] == " "
 
 
 class TestCreateIssueEpicSearch:
@@ -148,3 +202,49 @@ class TestJiraInitAuth:
 
         call_kwargs = mock_jira_class.call_args.kwargs
         assert call_kwargs["options"] == {"rest_api_version": "3"}
+
+
+def _post_request_json(kwargs: dict) -> dict:
+    raw = kwargs.get("data")
+    if raw is None:
+        return kwargs.get("json") or {}
+    if isinstance(raw, (bytes, bytearray)):
+        raw = raw.decode()
+    return json.loads(raw) if isinstance(raw, str) else raw
+
+
+def _assert_adf_doc(value: object) -> None:
+    assert isinstance(value, dict), f"expected ADF doc dict, got {type(value).__name__}"
+    assert value.get("type") == "doc"
+    assert value.get("version") == 1
+
+
+class TestJiraCommentPostAdfPayload:
+    def test_comment_post_json_uses_adf_doc_body_not_string(self, patch_jira_api_requests, fake_issue_key, jira):
+        text = "hello from test"
+        jira.comment(fake_issue_key, text)
+        comment_urls = [u for u in patch_jira_api_requests["post"] if u.endswith("/comment")]
+        assert len(comment_urls) == 1
+        _args, kwargs = patch_jira_api_requests["post"][comment_urls[0]]
+        payload = _post_request_json(kwargs)
+        assert "body" in payload
+        assert not isinstance(payload["body"], str), (
+            "Jira Cloud REST v3 expects comment body as ADF, not a plain string"
+        )
+        _assert_adf_doc(payload["body"])
+        assert payload["body"]["content"][0]["content"][0]["text"] == text
+
+    def test_comment_post_sanitizes_empty_text_in_adf_dict(self, patch_jira_api_requests, fake_issue_key, jira):
+        raw = {
+            "type": "doc",
+            "version": 1,
+            "content": [
+                {"type": "paragraph", "content": [{"type": "text", "text": ""}]},
+            ],
+        }
+        jira.comment(fake_issue_key, raw)
+        comment_urls = [u for u in patch_jira_api_requests["post"] if u.endswith("/comment")]
+        assert len(comment_urls) == 1
+        _args, kwargs = patch_jira_api_requests["post"][comment_urls[0]]
+        payload = _post_request_json(kwargs)
+        assert payload["body"]["content"][0]["content"][0]["text"] == " "

--- a/tests/unittests/objects/jira/test_jira_adf.py
+++ b/tests/unittests/objects/jira/test_jira_adf.py
@@ -1,0 +1,238 @@
+from src.objects.jira_adf import (
+    adf_doc,
+    adf_mention,
+    closed_by_firewatch_adf,
+    description_to_plain_text_for_search,
+    heading,
+    inline_text,
+    paragraph,
+    plain_text_to_adf_doc,
+    sanitize_jira_adf_doc,
+)
+
+
+class TestPlainTextToAdfDoc:
+    def test_single_paragraph_matches_minimal_doc_shape(self):
+        plain = "Line one\nLine two"
+        assert plain_text_to_adf_doc(plain) == {
+            "type": "doc",
+            "version": 1,
+            "content": [
+                {
+                    "type": "paragraph",
+                    "content": [{"type": "text", "text": plain}],
+                }
+            ],
+        }
+
+
+class TestAdfDoc:
+    def test_root_has_doc_type_version_and_content(self):
+        p = paragraph(inline_text("only"))
+        doc = adf_doc(p)
+        assert doc == {
+            "type": "doc",
+            "version": 1,
+            "content": [p],
+        }
+
+
+class TestParagraph:
+    def test_paragraph_wraps_inline_nodes(self):
+        assert paragraph(inline_text("a"), inline_text("b", bold=True)) == {
+            "type": "paragraph",
+            "content": [
+                {"type": "text", "text": "a"},
+                {"type": "text", "text": "b", "marks": [{"type": "strong"}]},
+            ],
+        }
+
+
+class TestHeading:
+    def test_heading_level_four_for_section_titles(self):
+        assert heading(
+            4,
+            inline_text("Section"),
+        ) == {
+            "type": "heading",
+            "attrs": {"level": 4},
+            "content": [{"type": "text", "text": "Section"}],
+        }
+
+
+class TestInlineText:
+    def test_plain_text_node(self):
+        assert inline_text("hello") == {"type": "text", "text": "hello"}
+
+    def test_bold_uses_strong_mark(self):
+        assert inline_text("x", bold=True) == {
+            "type": "text",
+            "text": "x",
+            "marks": [{"type": "strong"}],
+        }
+
+    def test_italic_uses_em_mark(self):
+        assert inline_text("x", italic=True) == {
+            "type": "text",
+            "text": "x",
+            "marks": [{"type": "em"}],
+        }
+
+    def test_link_uses_link_mark_with_href(self):
+        assert inline_text("firewatch", url="https://example.com/fw") == {
+            "type": "text",
+            "text": "firewatch",
+            "marks": [{"type": "link", "attrs": {"href": "https://example.com/fw"}}],
+        }
+
+    def test_bold_link_combines_marks_in_order(self):
+        assert inline_text("label", bold=True, url="https://x.test") == {
+            "type": "text",
+            "text": "label",
+            "marks": [
+                {"type": "strong"},
+                {"type": "link", "attrs": {"href": "https://x.test"}},
+            ],
+        }
+
+
+class TestMention:
+    def test_mention_uses_cloud_account_id_and_display_stub(self):
+        account_id = "5b10a" + "2844b82e0069f46e23a"
+        assert adf_mention(account_id, "@User Name") == {
+            "type": "mention",
+            "attrs": {
+                "id": account_id,
+                "text": "@User Name",
+            },
+        }
+
+
+class TestSanitizeJiraAdfDoc:
+    def test_empty_text_node_becomes_space(self):
+        doc = adf_doc(paragraph(inline_text("")))
+        out = sanitize_jira_adf_doc(doc)
+        assert out["content"][0]["content"][0]["text"] == " "
+
+    def test_none_text_node_becomes_space(self):
+        doc = {
+            "type": "doc",
+            "version": 1,
+            "content": [{"type": "paragraph", "content": [{"type": "text"}]}],
+        }
+        out = sanitize_jira_adf_doc(doc)
+        assert out["content"][0]["content"][0]["text"] == " "
+
+    def test_strips_nul_bytes_from_text(self):
+        doc = adf_doc(paragraph(inline_text("a\x00b")))
+        out = sanitize_jira_adf_doc(doc)
+        assert out["content"][0]["content"][0]["text"] == "ab"
+
+    def test_heading_with_empty_content_gets_placeholder(self):
+        doc = {"type": "doc", "version": 1, "content": [{"type": "heading", "attrs": {"level": 4}, "content": []}]}
+        out = sanitize_jira_adf_doc(doc)
+        assert out["content"][0]["content"] == [{"type": "text", "text": " "}]
+
+    def test_keeps_strong_mark_when_dropping_invalid_link(self):
+        raw = {
+            "type": "text",
+            "text": "x",
+            "marks": [
+                {"type": "strong"},
+                {"type": "link", "attrs": {"href": ""}},
+            ],
+        }
+        fixed = sanitize_jira_adf_doc({
+            "type": "doc",
+            "version": 1,
+            "content": [{"type": "paragraph", "content": [raw]}],
+        })
+        node = fixed["content"][0]["content"][0]
+        assert node["marks"] == [{"type": "strong"}]
+
+    def test_strips_link_mark_when_href_empty(self):
+        raw = {
+            "type": "text",
+            "text": "x",
+            "marks": [{"type": "link", "attrs": {"href": ""}}],
+        }
+        fixed = sanitize_jira_adf_doc({
+            "type": "doc",
+            "version": 1,
+            "content": [{"type": "paragraph", "content": [raw]}],
+        })
+        assert "marks" not in fixed["content"][0]["content"][0]
+
+    def test_empty_paragraph_gets_placeholder_text(self):
+        doc = {"type": "doc", "version": 1, "content": [{"type": "paragraph", "content": []}]}
+        out = sanitize_jira_adf_doc(doc)
+        assert out["content"][0]["content"] == [{"type": "text", "text": " "}]
+
+
+class TestDescriptionToPlainTextForSearch:
+    def test_none_returns_empty(self):
+        assert description_to_plain_text_for_search(None) == ""
+
+    def test_plain_string_passthrough(self):
+        assert description_to_plain_text_for_search("plain") == "plain"
+
+    def test_block_without_content_list_yields_empty_for_unknown_node(self):
+        assert description_to_plain_text_for_search({"type": "rule"}) == ""
+
+    def test_includes_mention_stub(self):
+        doc = adf_doc(paragraph(adf_mention("acc-1", "@qa")))
+        assert "@qa" in description_to_plain_text_for_search(doc)
+
+    def test_hard_break_inserts_newline(self):
+        doc = {
+            "type": "doc",
+            "version": 1,
+            "content": [
+                {
+                    "type": "paragraph",
+                    "content": [
+                        {"type": "text", "text": "a"},
+                        {"type": "hardBreak"},
+                        {"type": "text", "text": "b"},
+                    ],
+                },
+            ],
+        }
+        assert description_to_plain_text_for_search(doc) == "a\nb"
+
+    def test_non_doc_dict_uses_recursive_plain_text(self):
+        block = {"type": "paragraph", "content": [{"type": "text", "text": "only"}]}
+        assert description_to_plain_text_for_search(block) == "only"
+
+    def test_non_dict_non_str_returns_empty(self):
+        assert description_to_plain_text_for_search(0) == ""  # type: ignore[arg-type]
+
+
+class TestClosedByFirewatchAdf:
+    def test_returns_doc_with_link_to_repo(self):
+        doc = closed_by_firewatch_adf()
+        assert doc["type"] == "doc"
+        assert doc["version"] == 1
+        assert "firewatch" in description_to_plain_text_for_search(doc)
+
+
+class TestComposedDocument:
+    def test_doc_with_heading_paragraph_and_mixed_inline(self):
+        doc = adf_doc(
+            heading(4, inline_text("Title")),
+            paragraph(
+                inline_text("See "),
+                inline_text("docs", url="https://docs.example.com"),
+                inline_text(" and "),
+                adf_mention("acc-1", "@qa"),
+                inline_text("."),
+            ),
+        )
+        assert doc["type"] == "doc"
+        assert doc["version"] == 1
+        assert len(doc["content"]) == 2
+        assert doc["content"][0]["type"] == "heading"
+        assert doc["content"][1]["type"] == "paragraph"
+        mention = doc["content"][1]["content"][3]
+        assert mention["type"] == "mention"
+        assert mention["attrs"]["id"] == "acc-1"


### PR DESCRIPTION
## Summary

Jira Cloud REST v3 requires comment and transition bodies as [Atlassian Document Format](https://developer.atlassian.com/cloud/jira/platform/apis/document/structure/) (ADF) objects, not plain strings. This PR adds ADF helpers and rewires every comment and transition path to use them.

### What changed

**New module** `src/objects/jira_adf.py`
- Composable helpers: `adf_doc`, `paragraph`, `heading`, `inline_text` (with `strong`/`em`/`link` marks), `adf_mention`
- Convenience wrappers: `plain_text_to_adf_doc`, `closed_by_firewatch_adf`
- Read-path utility: `description_to_plain_text_for_search` (flattens an ADF doc to plain text for regex)

**Comment and transition REST** (`src/objects/jira_base.py`)
- `_post_issue_comment_adf` -- direct `POST /rest/api/3/issue/{key}/comment` with `Content-Type: application/json` and ADF body
- `_transition_issue_with_adf_comment` -- direct `POST /rest/api/3/issue/{key}/transitions` with ADF comment in the `update` payload
- `comment()` accepts `str` (auto-wrapped) or a pre-built ADF dict
- `close_issue()` and close-on-create both use the new transition path

**Template migration** (`src/report/report.py`)
- `add_passing_job_comment` and `add_duplicate_comment` rewritten from wiki markup (`h4.`, `*bold*`, `[label|url]`) to structured ADF

**Escalation fix** (`src/escalation/jira_escalation.py`)
- Fixed `jira.comment(jira_issue, comment)` -- args were swapped vs the method signature; now uses `issue_id=jira_issue.key`
- Mention uses `adf_mention(account_id, ...)` instead of wiki `[~accountId:...]`
- `extract_prow_job_name`/`extract_prow_job_link` now receive flattened text via `description_to_plain_text_for_search`, so they work on both string and ADF descriptions

### Unit test changes

**New** `tests/unittests/objects/jira/test_jira_adf.py`
- Covers every helper: `plain_text_to_adf_doc`, `adf_doc`, `paragraph`, `heading`, `inline_text` (plain, bold, link, bold+link), `adf_mention`
- Composed-document test: heading + paragraph with mixed inline nodes and a mention

**Updated** `tests/unittests/objects/jira/test_jira.py`
- `TestJiraCommentPostAdfPayload`: asserts `POST .../comment` payload contains an ADF `body` dict (not a plain string) with expected text content

**Updated** `tests/unittests/objects/jira/test_firewatch_objects_jira_base_close_issue.py`
- `test_close_issue_success`: asserts `POST .../transitions` payload carries an ADF comment body; added local `jira` fixture with caplog handler
- `test_close_issue_jira_error` / `test_close_issue_unexpected_exception`: mock `find_transitionid_by_name` + `_session.post` instead of `transition_issue` to match the new direct-POST path

**Updated** `tests/unittests/functions/escalation/test_jira_escalation.py`
- `TestDescriptionToPlainTextForSearch`: string pass-through, ADF flattening, prow regex after flatten, and `TypeError` on raw ADF dict without flattening
- Escalation comment assertion updated: checks `comment` kwarg is an ADF dict with a mention node whose `attrs.id` matches the assignee account id

**Updated** `tests/unittests/conftest.py`
- Fake API request fixtures updated for direct session POST routing (comment and transition endpoints)

## References

- [INTEROP-8970](https://redhat.atlassian.net/browse/INTEROP-8970)
- Follow-up to [#267](https://github.com/RedHatQE/firewatch/pull/267)

## Test plan

- [x] `pytest tests/unittests/` -- 182 tests pass
- [x] `pre-commit run --all-files` -- all hooks pass (mypy, ruff, flake8, detect-secrets)
- [ ] Jira Cloud smoke: post a comment, close an issue, run escalation with a mention