### PR TITLE
Handle Jira API failures when decorating existing tickets (labels/comments)

### DIFF
--- a/src/objects/jira_base.py
+++ b/src/objects/jira_base.py
@@ -126,7 +126,8 @@ class Jira:
         LOGGER.info(
             "A Jira issue will be reported.",
         )
-        issue = self.connection.create_issue(issue_dict)
+        response = self._jira_request("post", f"{self.url}/rest/api/3/issue", {"fields": issue_dict})
+        issue = self.connection.issue(response.json()["key"])
         LOGGER.info(
             f"{issue} has been reported to Jira: {self.url}/browse/{issue}",
         )
@@ -216,19 +217,16 @@ class Jira:
 
         return issues
 
+    def _jira_request(self, method: str, url: str, payload: dict[str, Any]) -> Any:
+        fn = getattr(self.connection._session, method)
+        response = fn(url, json=payload, headers={"Content-Type": "application/json"})
+        if not response.ok:
+            raise JIRAError(response.text, response.status_code, response.url)
+        return response
+
     def _post_issue_comment_adf(self, issue_key: str, adf_body: dict[str, Any]) -> None:
         url = self.connection._get_url(f"issue/{issue_key}/comment")
-        response = self.connection._session.post(
-            url,
-            json={"body": sanitize_jira_adf_doc(adf_body)},
-            headers={"Content-Type": "application/json"},
-        )
-        if not response.ok:
-            raise JIRAError(
-                text=response.text,
-                status_code=response.status_code,
-                url=response.url,
-            )
+        self._jira_request("post", url, {"body": sanitize_jira_adf_doc(adf_body)})
 
     def _transition_issue_with_adf_comment(
         self,
@@ -248,17 +246,7 @@ class Jira:
             "update": {"comment": [{"add": {"body": sanitize_jira_adf_doc(adf_body)}}]},
         }
         url = self.connection._get_url(f"issue/{issue_key}/transitions")
-        response = self.connection._session.post(
-            url,
-            json=payload,
-            headers={"Content-Type": "application/json"},
-        )
-        if not response.ok:
-            raise JIRAError(
-                text=response.text,
-                status_code=response.status_code,
-                url=response.url,
-            )
+        self._jira_request("post", url, payload)
 
     @ignore_exceptions(retry=3, retry_interval=1, raise_final_exception=True, logger=LOGGER)
     def comment(self, issue_id: str, comment: str | dict[str, Any]) -> None:
@@ -420,47 +408,38 @@ class Jira:
         return self.connection.issue(id=issue)
 
     @ignore_exceptions(retry=3, retry_interval=1, raise_final_exception=True, logger=LOGGER)
-    def add_labels_to_issue(self, issue_id_or_key: str, labels: list[str]) -> Issue:
-        """
-        Append the given labels to a Jira issue, as identified by the issue's key or ID field value.
-        If the label already exists on the issue, it is not duplicated.
-        Returns the value of the modified issue.
-
-        Args:
-            issue_id_or_key (str): The ID or key field value of the Jira Issue object to return.
-            labels: list[str]: The list of labels to add to the Jira issue.
-        Returns:
-            Issue: A Jira Issue object.
-        """
+    def _update_issue_labels(
+        self,
+        issue_id_or_key: str,
+        labels: list[str],
+        operation: str,
+    ) -> tuple[Issue, bool]:
         issue = self.get_issue_by_id_or_key(issue_id_or_key)
-        payload = {"update": {"labels": [{"add": label} for label in labels]}}
-        # Workaround: use the session PUT with explicit Content-Type because the python-jira
-        # library's issue.update() does not set Content-Type: application/json on the request.
-        # Jira Cloud rejects that with HTTP 415. Prefer self.connection.* elsewhere; this is
-        # the only call that bypasses the library until pycontribs/jira fixes the header.
+        payload = {"update": {"labels": [{operation: label} for label in labels]}}
         try:
-            response = self.connection._session.put(
-                issue.self,
-                json=payload,
-                headers={"Content-Type": "application/json"},
-            )
-            if not response.ok:
-                raise JIRAError(
-                    response.status_code,
-                    response.text,
-                    response.url,
-                )
+            self._jira_request("put", issue.self, payload)
         except JIRAError as error:
             LOGGER.error(
-                f"Failed to add labels {labels} to issue {issue_id_or_key}. Error: {error.text}",
+                "Failed to %s labels %s on issue %s. Error: %s",
+                operation,
+                labels,
+                issue_id_or_key,
+                error.text,
             )
-            if error.status_code == 403:
+            if error.status_code in (400, 403):
                 LOGGER.info(
-                    "This error can be caused by missing permissions on the Jira user."
+                    "This may be caused by project configuration, missing permissions, or the Jira user."
                     ' Please see the "Jira User Permissions" section in the README for more information.',
                 )
+                return issue, False
             raise
-        return issue
+        return issue, True
+
+    def add_labels_to_issue(self, issue_id_or_key: str, labels: list[str]) -> tuple[Issue, bool]:
+        return self._update_issue_labels(issue_id_or_key, labels, "add")
+
+    def remove_labels_from_issue(self, issue_id_or_key: str, labels: list[str]) -> tuple[Issue, bool]:
+        return self._update_issue_labels(issue_id_or_key, labels, "remove")
 
     @ignore_exceptions(retry=3, retry_interval=1, raise_final_exception=True, logger=LOGGER)
     def get_issue_by_id_or_key_with_changelog(self, issue: str) -> Issue:

--- a/src/report/report.py
+++ b/src/report/report.py
@@ -2,10 +2,12 @@ import os
 import shutil
 from datetime import datetime
 from typing import Any
+from typing import Literal
 from typing import Optional
 from typing import Tuple
 
 import jira
+from jira.exceptions import JIRAError
 from simple_logger.logger import get_logger
 
 from src.objects.configuration import Configuration
@@ -55,7 +57,11 @@ class Report:
             if open_bugs:
                 for bug in open_bugs:
                     self.logger.info(f"Adding retrigger label to issue: {bug}")
-                    self.add_retrigger_job_label(jira=firewatch_config.jira, issue_id=bug)
+                    self.add_retrigger_job_label(
+                        jira=firewatch_config.jira,
+                        issue_id=bug,
+                        job=job,
+                    )
             else:
                 self.logger.warning(f"No open bugs found for retriggered job: {job.name}")
 
@@ -367,6 +373,24 @@ class Report:
             matching_rules = sorted(matching_rules, key=lambda x: x.step.__eq__(failure.step), reverse=True)
         return matching_rules
 
+    def _safe_jira_comment(
+        self,
+        jira: Jira,
+        issue_id: str,
+        comment: str | dict[str, Any],
+        *,
+        context: str,
+    ) -> None:
+        try:
+            jira.comment(issue_id=issue_id, comment=comment)
+        except JIRAError as err:
+            self.logger.warning(
+                "Could not add %s to %s: %s",
+                context,
+                issue_id,
+                err.text,
+            )
+
     def add_passing_job_comment(self, job: Job, jira: Jira, issue_id: str) -> None:
         """
         Used to make a comment on a Jira issue that is open but has had a passing job since the issue was filed.
@@ -410,7 +434,48 @@ class Report:
                 inline_text("."),
             ),
         )
-        jira.comment(issue_id=issue_id, comment=body)
+        self._safe_jira_comment(
+            jira,
+            issue_id,
+            body,
+            context="passing-job comment",
+        )
+
+    def _try_jira_labels(
+        self,
+        jira: Jira,
+        issue_id: str,
+        labels: list[str],
+        *,
+        context: Literal["passing-job", "retrigger"],
+    ) -> bool:
+        try:
+            _, applied = jira.add_labels_to_issue(
+                issue_id_or_key=issue_id,
+                labels=labels,
+            )
+        except JIRAError as err:
+            if context == "passing-job":
+                self.logger.warning(
+                    "Could not add passing-job label to %s: %s",
+                    issue_id,
+                    err.text,
+                )
+            else:
+                self.logger.warning(
+                    "Could not add retrigger label to %s: %s",
+                    issue_id,
+                    err.text,
+                )
+            return False
+        if not applied:
+            if context == "passing-job":
+                self.logger.warning(
+                    "Could not add passing-job label to %s (label not applied by Jira).",
+                    issue_id,
+                )
+            return False
+        return True
 
     def add_passing_job_label(self, jira: Jira, issue_id: str) -> None:
         """
@@ -423,26 +488,49 @@ class Report:
         Returns:
             None
         """
-        jira.add_labels_to_issue(
-            issue_id_or_key=issue_id,
-            labels=[JOB_PASSED_SINCE_TICKET_CREATED_LABEL],
+        self._try_jira_labels(
+            jira,
+            issue_id,
+            [JOB_PASSED_SINCE_TICKET_CREATED_LABEL],
+            context="passing-job",
         )
 
-    def add_retrigger_job_label(self, jira: Jira, issue_id: str) -> None:
+    def _retrigger_fallback_comment_body(self, job: Job) -> str:
+        return (
+            f"firewatch could not add the label {JOB_RETRIGGERED_IN_CURRENT_WEEK_LABEL}. "
+            f"This job build was a retrigger in the current week. "
+            f"Prow run: https://prow.ci.openshift.org/view/gs/test-platform-results/logs/{job.name}/{job.build_id} "
+            f"Build ID: {job.build_id}"
+        )
+
+    def add_retrigger_job_label(self, jira: Jira, issue_id: str, job: Job) -> None:
         """
         Used to add a label on a Jira issue that the latest build is retrigger of job.
 
         Args:
             jira (Jira): Jira object.
             issue_id (str): Issue ID of the open issue to comment on.
+            job (Job): Job object for fallback prow link text if the label cannot be set.
 
         Returns:
             None
         """
-        jira.add_labels_to_issue(
-            issue_id_or_key=issue_id,
-            labels=[JOB_RETRIGGERED_IN_CURRENT_WEEK_LABEL],
-        )
+        if not self._try_jira_labels(
+            jira,
+            issue_id,
+            [JOB_RETRIGGERED_IN_CURRENT_WEEK_LABEL],
+            context="retrigger",
+        ):
+            self.logger.warning(
+                "Adding fallback comment on %s because the retrigger label could not be applied.",
+                issue_id,
+            )
+            self._safe_jira_comment(
+                jira,
+                issue_id,
+                self._retrigger_fallback_comment_body(job),
+                context="fallback retrigger comment",
+            )
 
     def add_duplicate_comment(
         self,

--- a/tests/unittests/conftest.py
+++ b/tests/unittests/conftest.py
@@ -517,6 +517,15 @@ def patch_jira_api_requests(
         elif url_contains_fake_issue_id_or_key(url) and url_contains_issue_subpath and url.endswith("/attachments"):
             LOGGER.info(f"Faking Jira file upload: {url}")
             return fake_issue_add_attachment_response
+        elif url.endswith("/rest/api/3/issue"):
+            return MockJiraApiResponse(
+                _json={
+                    "id": fake_issue_id,
+                    "key": fake_issue_key,
+                    "self": f"{url}/{fake_issue_id}",
+                },
+                _status_code=201,
+            )
         else:
             LOGGER.info(f"Unpatched POST request to: {url}")
             monkeypatch.undo()

--- a/tests/unittests/functions/report/test_firewatch_functions_report_jira_graceful_failures.py
+++ b/tests/unittests/functions/report/test_firewatch_functions_report_jira_graceful_failures.py
@@ -1,0 +1,160 @@
+from unittest.mock import MagicMock
+
+import pytest
+from jira.exceptions import JIRAError
+
+from src.objects.job import Job
+from src.report.report import Report
+
+
+@pytest.fixture
+def report_instance():
+    report = Report.__new__(Report)
+    report.logger = MagicMock()
+    yield report
+
+
+@pytest.fixture
+def sample_job():
+    job = MagicMock(spec=Job)
+    job.name = "periodic-ci-example"
+    job.build_id = "12345"
+    return job
+
+
+def test_add_retrigger_job_label_does_not_comment_when_labels_applied(
+    report_instance,
+    sample_job,
+):
+    jira = MagicMock()
+    jira.add_labels_to_issue.return_value = (MagicMock(), True)
+
+    report_instance.add_retrigger_job_label(
+        jira=jira,
+        issue_id="ROX-1",
+        job=sample_job,
+    )
+
+    jira.add_labels_to_issue.assert_called_once()
+    jira.comment.assert_not_called()
+
+
+def test_add_retrigger_job_label_posts_fallback_comment_when_labels_not_applied(
+    report_instance,
+    sample_job,
+):
+    jira = MagicMock()
+    jira.add_labels_to_issue.return_value = (MagicMock(), False)
+
+    report_instance.add_retrigger_job_label(
+        jira=jira,
+        issue_id="ROX-1",
+        job=sample_job,
+    )
+
+    jira.add_labels_to_issue.assert_called_once()
+    jira.comment.assert_called_once()
+    body = jira.comment.call_args.kwargs["comment"]
+    assert jira.comment.call_args.kwargs["issue_id"] == "ROX-1"
+    assert "retrigger" in body.lower()
+    assert sample_job.name in body
+    assert sample_job.build_id in body
+    report_instance.logger.warning.assert_any_call(
+        "Adding fallback comment on %s because the retrigger label could not be applied.",
+        "ROX-1",
+    )
+
+
+def test_add_retrigger_job_label_attempts_fallback_comment_when_add_labels_raises_jira_error(
+    report_instance,
+    sample_job,
+):
+    jira = MagicMock()
+    jira.add_labels_to_issue.side_effect = JIRAError("Internal server error", 500, "https://jira/x")
+
+    report_instance.add_retrigger_job_label(
+        jira=jira,
+        issue_id="ROX-1",
+        job=sample_job,
+    )
+
+    jira.add_labels_to_issue.assert_called_once()
+    jira.comment.assert_called_once()
+    assert jira.comment.call_args.kwargs["issue_id"] == "ROX-1"
+    body = jira.comment.call_args.kwargs["comment"]
+    assert "retrigger" in body.lower()
+    assert sample_job.name in body
+    report_instance.logger.warning.assert_any_call(
+        "Could not add retrigger label to %s: %s",
+        "ROX-1",
+        "Internal server error",
+    )
+    report_instance.logger.warning.assert_any_call(
+        "Adding fallback comment on %s because the retrigger label could not be applied.",
+        "ROX-1",
+    )
+
+
+def test_add_retrigger_job_label_swallows_fallback_comment_jira_error(
+    report_instance,
+    sample_job,
+):
+    jira = MagicMock()
+    jira.add_labels_to_issue.return_value = (MagicMock(), False)
+    jira.comment.side_effect = JIRAError("bad", 400, "https://jira/x")
+
+    report_instance.add_retrigger_job_label(
+        jira=jira,
+        issue_id="ROX-1",
+        job=sample_job,
+    )
+
+    jira.comment.assert_called_once()
+    report_instance.logger.warning.assert_any_call(
+        "Adding fallback comment on %s because the retrigger label could not be applied.",
+        "ROX-1",
+    )
+    report_instance.logger.warning.assert_any_call(
+        "Could not add %s to %s: %s",
+        "fallback retrigger comment",
+        "ROX-1",
+        "bad",
+    )
+
+
+def test_add_passing_job_comment_logs_warning_on_jira_error(report_instance, sample_job):
+    jira = MagicMock()
+    jira.comment.side_effect = JIRAError("Comment body is not valid!", 400, "https://jira/x")
+
+    report_instance.add_passing_job_comment(
+        job=sample_job,
+        jira=jira,
+        issue_id="ROX-1",
+    )
+
+    jira.comment.assert_called_once()
+    report_instance.logger.warning.assert_called_once_with(
+        "Could not add %s to %s: %s",
+        "passing-job comment",
+        "ROX-1",
+        "Comment body is not valid!",
+    )
+
+
+def test_add_passing_job_label_logs_warning_when_labels_not_applied(report_instance):
+    jira = MagicMock()
+    jira.add_labels_to_issue.return_value = (MagicMock(), False)
+
+    report_instance.add_passing_job_label(jira=jira, issue_id="ROX-1")
+
+    jira.add_labels_to_issue.assert_called_once()
+    report_instance.logger.warning.assert_called()
+
+
+def test_add_passing_job_label_logs_warning_on_jira_error(report_instance):
+    jira = MagicMock()
+    jira.add_labels_to_issue.side_effect = JIRAError("no", 403, "https://jira/x")
+
+    report_instance.add_passing_job_label(jira=jira, issue_id="ROX-1")
+
+    report_instance.logger.warning.assert_called()

--- a/tests/unittests/functions/report/test_firewatch_functions_report_retrigger_wiring.py
+++ b/tests/unittests/functions/report/test_firewatch_functions_report_retrigger_wiring.py
@@ -1,0 +1,48 @@
+from unittest.mock import MagicMock
+
+
+from src.objects.job import Job
+from src.report.report import Report
+
+
+def test_report_passes_job_to_add_retrigger_job_label_when_retriggered(monkeypatch, tmp_path):
+    job = MagicMock(spec=Job)
+    job.is_rehearsal = False
+    job.is_retriggered = True
+    job.failures = []
+    job.name = "periodic-ci-example"
+    job.build_id = "991"
+    job.download_path = tmp_path / "dl"
+    job.has_test_failures = False
+    job.has_pod_failures = False
+
+    jira_client = MagicMock()
+    config = MagicMock()
+    config.jira = jira_client
+    config.keep_job_dir = True
+    config.fail_with_test_failures = False
+    config.fail_with_pod_failures = False
+    config.success_rules = []
+    config.verbose_test_failure_reporting = False
+
+    get_open_calls = []
+
+    def _get_open_bugs(self, job_name, jira):
+        get_open_calls.append(job_name)
+        if len(get_open_calls) == 1:
+            return ["ISSUE-1"]
+        return []
+
+    monkeypatch.setattr(Report, "_get_open_bugs", _get_open_bugs)
+
+    captured = []
+
+    def _capture_retrigger(self, jira, issue_id, job):
+        captured.append((jira, issue_id, job))
+
+    monkeypatch.setattr(Report, "add_retrigger_job_label", _capture_retrigger)
+
+    Report(firewatch_config=config, job=job)
+
+    assert captured == [(jira_client, "ISSUE-1", job)]
+    assert captured[0][2] is job

--- a/tests/unittests/objects/jira/test_jira.py
+++ b/tests/unittests/objects/jira/test_jira.py
@@ -1,7 +1,9 @@
 import json
 
 import pytest
+import pyhelper_utils.general as pyhelper_general
 from jira import Issue
+from jira.exceptions import JIRAError
 from unittest.mock import MagicMock, patch
 
 from src.objects.jira_base import Jira
@@ -27,6 +29,35 @@ def fake_attachment_path(tmp_path):
     yield path
 
 
+def _mock_error_response(status_code: int, text: str, url: str = "https://example/rest/api/3/issue/1"):
+    resp = MagicMock()
+    resp.ok = False
+    resp.status_code = status_code
+    resp.text = text
+    resp.url = url
+    return resp
+
+
+@pytest.fixture
+def mock_jira(monkeypatch):
+    monkeypatch.setattr(Jira, "__init__", lambda self, jira_config_path=None: None)
+    jira = Jira()
+    jira.url = DEFAULT_JIRA_SERVER_URL
+    jira.connection = MagicMock()
+    jira.connection._session = MagicMock()
+
+    post_response = MagicMock()
+    post_response.ok = True
+    post_response.json.return_value = {"key": "TEST-1", "id": "10001"}
+    jira.connection._session.post.return_value = post_response
+
+    created_issue = MagicMock()
+    created_issue.key = "TEST-1"
+    jira.connection.issue.return_value = created_issue
+
+    return jira
+
+
 class TestJiraApiRespondsWithSuccess:
     def test_get_issue_by_id_returns_jira_issue_from_jira_api_client_with_matching_issue_id(self, fake_issue_id, jira):
         issue = jira.get_issue_by_id_or_key(issue=fake_issue_id)
@@ -39,8 +70,9 @@ class TestJiraApiRespondsWithSuccess:
         """Adding labels uses PUT with Content-Type: application/json to avoid 415 from Jira Cloud."""
         labels = ["retrigger", "firewatch"]
         expected = {"update": {"labels": [{"add": "retrigger"}, {"add": "firewatch"}]}}
-        result = jira.add_labels_to_issue(issue_id_or_key=fake_issue_id, labels=labels)
-        assert result is not None
+        issue, applied = jira.add_labels_to_issue(issue_id_or_key=fake_issue_id, labels=labels)
+        assert issue is not None
+        assert applied is True
         assert len(patch_jira_api_requests["put"]) == 1
         _url, (data, args, kwargs) = next(iter(patch_jira_api_requests["put"].items()))
         assert kwargs.get("headers", {}).get("Content-Type") == "application/json"
@@ -49,6 +81,109 @@ class TestJiraApiRespondsWithSuccess:
         payload = kwargs["json"]
         assert "fields" not in payload
         assert payload == expected
+
+    def test_remove_labels_from_issue_sends_content_type_json_for_cloud_compatibility(
+        self, fake_issue_id, jira, patch_jira_api_requests
+    ):
+        labels = ["job_passed_since_ticket_created"]
+        expected = {"update": {"labels": [{"remove": "job_passed_since_ticket_created"}]}}
+        issue, applied = jira.remove_labels_from_issue(issue_id_or_key=fake_issue_id, labels=labels)
+        assert issue is not None
+        assert applied is True
+        assert len(patch_jira_api_requests["put"]) == 1
+        _url, (data, args, kwargs) = next(iter(patch_jira_api_requests["put"].items()))
+        assert kwargs.get("headers", {}).get("Content-Type") == "application/json"
+        assert kwargs.get("json") == expected
+        assert data is None
+
+    def test_create_issue_sends_content_type_json_for_cloud_compatibility(self, jira, patch_jira_api_requests):
+        jira.create_issue(
+            project="TEST",
+            summary="S",
+            description="D",
+            issue_type="Bug",
+        )
+        create_urls = [u for u in patch_jira_api_requests["post"] if u.endswith("/rest/api/3/issue")]
+        assert len(create_urls) == 1
+        _args, kwargs = patch_jira_api_requests["post"][create_urls[0]]
+        assert kwargs.get("headers", {}).get("Content-Type") == "application/json"
+        payload = kwargs.get("json") or {}
+        assert "fields" in payload
+        fields = payload["fields"]
+        assert fields["project"] == {"key": "TEST"}
+        assert fields["summary"] == "S"
+        assert fields["issuetype"] == {"name": "Bug"}
+        assert fields["description"] == _minimal_adf_doc("D")
+
+
+class TestJiraCreateIssueHttpError:
+    def test_create_issue_raises_jira_error_when_post_returns_non_ok(self, jira, monkeypatch):
+        monkeypatch.setattr(pyhelper_general, "sleep", lambda _: None)
+        err_text = '{"detail":"Method \'GET\' is not supported."}'
+        resp = _mock_error_response(405, err_text, url="https://example/rest/api/3/issue")
+
+        with patch.object(jira.connection._session, "post", return_value=resp):
+            with pytest.raises(JIRAError) as exc_info:
+                jira.create_issue(
+                    project="TEST",
+                    summary="S",
+                    description="D",
+                    issue_type="Bug",
+                )
+
+        assert exc_info.value.text == err_text
+        assert exc_info.value.status_code == 405
+        assert exc_info.value.url == resp.url
+
+
+class TestJiraAddLabelsHttpError:
+    @pytest.mark.parametrize(
+        "status_code,err_text",
+        [
+            (400, "Field 'labels' cannot be set. It is not on the appropriate screen, or unknown."),
+            (403, "You do not have permission to edit this issue."),
+        ],
+    )
+    def test_add_labels_to_issue_returns_false_on_recoverable_http_error(
+        self,
+        fake_issue_id,
+        jira,
+        caplog,
+        status_code,
+        err_text,
+    ):
+        resp = _mock_error_response(status_code, err_text)
+        with patch.object(jira.connection._session, "put", return_value=resp):
+            issue, applied = jira.add_labels_to_issue(issue_id_or_key=fake_issue_id, labels=["x"])
+        assert applied is False
+        assert issue.id == fake_issue_id
+        assert "Failed to add labels" in caplog.text
+        assert "project configuration, missing permissions, or the Jira user" in caplog.text
+
+
+class TestJiraRemoveLabelsHttpError:
+    @pytest.mark.parametrize(
+        "status_code,err_text",
+        [
+            (400, "Field 'labels' cannot be set. It is not on the appropriate screen, or unknown."),
+            (403, "You do not have permission to edit this issue."),
+        ],
+    )
+    def test_remove_labels_from_issue_returns_false_on_recoverable_http_error(
+        self,
+        fake_issue_id,
+        jira,
+        caplog,
+        status_code,
+        err_text,
+    ):
+        resp = _mock_error_response(status_code, err_text)
+        with patch.object(jira.connection._session, "put", return_value=resp):
+            issue, applied = jira.remove_labels_from_issue(issue_id_or_key=fake_issue_id, labels=["x"])
+        assert applied is False
+        assert issue.id == fake_issue_id
+        assert "Failed to remove labels" in caplog.text
+        assert "project configuration, missing permissions, or the Jira user" in caplog.text
 
 
 class TestJiraApiRespondsWithPermissionFailure:
@@ -83,19 +218,6 @@ def _minimal_adf_doc(plain_text: str) -> dict:
 
 
 class TestCreateIssueAdfDescription:
-    @pytest.fixture
-    def mock_jira(self, monkeypatch):
-        monkeypatch.setattr(Jira, "__init__", lambda self, jira_config_path=None: None)
-        jira = Jira()
-        jira.url = DEFAULT_JIRA_SERVER_URL
-        jira.connection = MagicMock()
-
-        created_issue = MagicMock()
-        created_issue.key = "TEST-1"
-        jira.connection.create_issue.return_value = created_issue
-
-        return jira
-
     def test_create_issue_passes_adf_description_for_jira_cloud_rest_v3(self, mock_jira):
         plain = "Line one\nLine two"
         mock_jira.create_issue(
@@ -104,8 +226,10 @@ class TestCreateIssueAdfDescription:
             description=plain,
             issue_type="Bug",
         )
-        mock_jira.connection.create_issue.assert_called_once()
-        fields = mock_jira.connection.create_issue.call_args[0][0]
+        mock_jira.connection._session.post.assert_called_once()
+        call_kwargs = mock_jira.connection._session.post.call_args.kwargs
+        assert call_kwargs["headers"]["Content-Type"] == "application/json"
+        fields = call_kwargs["json"]["fields"]
         assert fields["description"] == _minimal_adf_doc(plain)
 
     def test_create_issue_sanitizes_empty_description_text_node(self, mock_jira):
@@ -115,24 +239,12 @@ class TestCreateIssueAdfDescription:
             description="",
             issue_type="Bug",
         )
-        fields = mock_jira.connection.create_issue.call_args[0][0]
+        call_kwargs = mock_jira.connection._session.post.call_args.kwargs
+        fields = call_kwargs["json"]["fields"]
         assert fields["description"]["content"][0]["content"][0]["text"] == " "
 
 
 class TestCreateIssueEpicSearch:
-    @pytest.fixture
-    def mock_jira(self, monkeypatch):
-        monkeypatch.setattr(Jira, "__init__", lambda self, jira_config_path=None: None)
-        jira = Jira()
-        jira.url = DEFAULT_JIRA_SERVER_URL
-        jira.connection = MagicMock()
-
-        created_issue = MagicMock()
-        created_issue.key = "TEST-1"
-        jira.connection.create_issue.return_value = created_issue
-
-        return jira
-
     def test_epic_lookup_uses_unquoted_issue_key_for_cloud_compatibility(self, mock_jira):
         epic_issue = MagicMock()
         epic_issue.id = "20001"


### PR DESCRIPTION
## Summary

Gracefully handles Jira API failures when firewatch adds labels or comments to existing open bugs (retrigger flow, passing-job notifications). The report step no longer fails the job when decoration fails but the failure is already tracked in Jira.

`create_issue` now POSTs to the REST v3 issue endpoint with explicit `Content-Type: application/json`, matching the label-update workaround, so Jira Cloud no longer returns HTTP 405 when filing bugs or success stories.

## Changes

### `src/objects/jira_base.py`
- New `_jira_request` helper consolidates all session POST/PUT calls with `Content-Type: application/json`, replacing duplicated code in `_post_issue_comment_adf`, `_transition_issue_with_adf_comment`, and label updates
- `create_issue` uses `_jira_request` to POST to `/rest/api/3/issue`, then loads the created issue via `self.connection.issue(key)` (bypasses python-jira `create_issue` missing Content-Type)
- `add_labels_to_issue` and new `remove_labels_from_issue` extracted into shared `_update_issue_labels`; both return `tuple[Issue, bool]` and handle HTTP 400 alongside the existing 403 path so callers can degrade gracefully
- Fixed `JIRAError` constructor arg order (text, status_code, url)

### `src/report/report.py`
- `_safe_jira_comment` helper catches `JIRAError` and logs a warning instead of raising
- `_try_jira_labels` helper wraps `add_labels_to_issue`, catches both `JIRAError` and `applied=False`, and logs context-specific warnings
- `add_retrigger_job_label` now accepts a `job` parameter and posts a plaintext fallback comment with the prow link when the label cannot be applied
- `add_passing_job_label` and `add_passing_job_comment` use the new helpers to degrade gracefully instead of raising

### Tests
- **New** `test_firewatch_functions_report_jira_graceful_failures.py`: retrigger fallback comment, passing-job label/comment failures, safe comment error paths
- **New** `test_firewatch_functions_report_retrigger_wiring.py`: verifies `Report` passes `job` to `add_retrigger_job_label` during construction
- **Updated** `test_jira.py`: `remove_labels_from_issue` cloud compatibility, HTTP 400 and 403 label error handling, updated return-type assertions; `create_issue` session POST + Content-Type; ADF description tests assert `_session.post` payload; `mock_jira` fixture hoisted to module level
- **Updated** `conftest.py`: mock POST handler for `/rest/api/3/issue` create responses

## Tracking

Fixes #269
Fixes #272

- **Jira (sprint):** [INTEROP-8978](https://redhat.atlassian.net/browse/INTEROP-8978)
- **Jira (#272):** [INTEROP-8991](https://redhat.atlassian.net/browse/INTEROP-8991)
- **Jira (context):** Follow-up from [INTEROP-8970](https://redhat.atlassian.net/browse/INTEROP-8970) (firewatch Jira Cloud permissions restoration)

## Verification

- `uv run pytest tests/unittests`
- `uv run pre-commit run --all-files`