### PR TITLE
INTEROP-9063: Convert issue descriptions from wiki markup to ADF (fixes #271)

### DIFF
--- a/src/objects/jira_adf.py
+++ b/src/objects/jira_adf.py
@@ -94,6 +94,26 @@ def inline_text(
     return node
 
 
+def rule() -> dict[str, Any]:
+    return {"type": "rule"}
+
+
+def table(*rows: dict[str, Any]) -> dict[str, Any]:
+    return {"type": "table", "content": list(rows)}
+
+
+def table_row(*cells: dict[str, Any]) -> dict[str, Any]:
+    return {"type": "tableRow", "content": list(cells)}
+
+
+def table_header_cell(*blocks: dict[str, Any]) -> dict[str, Any]:
+    return {"type": "tableHeader", "content": list(blocks)}
+
+
+def table_cell(*blocks: dict[str, Any]) -> dict[str, Any]:
+    return {"type": "tableCell", "content": list(blocks)}
+
+
 def adf_mention(account_id: str, display_stub: str) -> dict[str, Any]:
     return {
         "type": "mention",

--- a/src/objects/jira_base.py
+++ b/src/objects/jira_base.py
@@ -56,7 +56,7 @@ class Jira:
         self,
         project: str,
         summary: str,
-        description: str,
+        description: str | dict[str, Any],
         issue_type: str,
         component: Optional[list[str]] = None,
         epic: Optional[str] = None,
@@ -91,10 +91,15 @@ class Jira:
         Returns:
             Issue: A Jira Issue object.
         """
+        adf_description = (
+            sanitize_jira_adf_doc(description)
+            if isinstance(description, dict)
+            else sanitize_jira_adf_doc(plain_text_to_adf_doc(description))
+        )
         issue_dict = {
             "project": {"key": project},
             "summary": summary,
-            "description": sanitize_jira_adf_doc(plain_text_to_adf_doc(description)),
+            "description": adf_description,
             "issuetype": {"name": issue_type},
         }
 

--- a/src/report/report.py
+++ b/src/report/report.py
@@ -17,6 +17,11 @@ from src.objects.jira_adf import adf_doc
 from src.objects.jira_adf import heading
 from src.objects.jira_adf import inline_text
 from src.objects.jira_adf import paragraph
+from src.objects.jira_adf import rule
+from src.objects.jira_adf import table
+from src.objects.jira_adf import table_cell
+from src.objects.jira_adf import table_header_cell
+from src.objects.jira_adf import table_row
 from src.objects.jira_base import Jira
 from src.objects.job import Job
 from src.objects.rule import Rule
@@ -736,55 +741,69 @@ class Report:
         failed_test_name: Optional[str] = None,
         success_issue: Optional[bool] = False,
         jira: Optional[Jira] = None,
-    ) -> str:
-        """
-        Used to generate the description of a bug to be filed in Jira.
-
-        Args:
-            job_name (str): Name of job that failed.
-            build_id (str): Build ID of failure.
-            step_name (Optional[str]): Name of the step that failed.
-            classification (Optional[str]): Classification of the failure.
-            failure_type (Optional[str]): Failure type.
-            failed_test_name (Optional[str]): Name of failed test, else None
-            success_issue (Optional [bool]): Description for success issue if True else for failure
-
-        Returns:
-            str: String object representing the description.
-        """
-        link_line_base_url = (
+    ) -> dict[str, Any]:
+        prow_base_url = (
             "https://qe-private-deck-ci.apps.ci.l2s4.p1.openshiftapps.com/view/gs/qe-private-deck/logs/"
             if job.is_private_deck
             else "https://prow.ci.openshift.org/view/gs/test-platform-results/logs/"
         )
-        link_line = f"*Prow Job Link:* [{job.name} #{job.build_id}|{link_line_base_url}{job.name}/{job.build_id}]"
-        build_id_line = f"*Build ID:* {job.build_id}"
-        job_history_link_line = f"*Job History:* [{job.name}|https://prow.ci.openshift.org/job-history/gs/test-platform-results/logs/{job.name}]"
-        firewatch_link_line = f"This {'issue' if success_issue else 'bug'} was filed using [firewatch in OpenShift CI|https://github.com/CSPI-QE/firewatch]"
+        prow_url = f"{prow_base_url}{job.name}/{job.build_id}"
+        job_history_url = f"https://prow.ci.openshift.org/job-history/gs/test-platform-results/logs/{job.name}"
+        fw_url = "https://github.com/CSPI-QE/firewatch"
 
-        # If the issue is being created for a failure
+        blocks: list[dict[str, Any]] = [
+            paragraph(
+                inline_text("Prow Job Link: ", bold=True),
+                inline_text(f"{job.name} #{job.build_id}", url=prow_url),
+            ),
+            paragraph(
+                inline_text("Build ID: ", bold=True),
+                inline_text(job.build_id or ""),
+            ),
+        ]
+
         if not success_issue:
-            classification_line = f"*Classification:* {classification}"
-            failed_step_line = f"*Failed Step:* {step_name}"
-            failed_test_line = f"*Failed Test:* {failed_test_name}" if failed_test_name else ""
+            blocks.append(paragraph(
+                inline_text("Classification: ", bold=True),
+                inline_text(classification or ""),
+            ))
+            blocks.append(paragraph(
+                inline_text("Failed Step: ", bold=True),
+                inline_text(step_name or ""),
+            ))
+            if failed_test_name:
+                blocks.append(paragraph(
+                    inline_text("Failed Test: ", bold=True),
+                    inline_text(failed_test_name),
+                ))
+            blocks.append(paragraph(
+                inline_text("Job History: ", bold=True),
+                inline_text(job.name, url=job_history_url),
+            ))
+
             past_bugs = self._get_past_bugs(
                 failed_step=step_name,  # type: ignore
                 failure_type=failure_type,  # type: ignore
                 failed_test_name=failed_test_name,  # type: ignore
                 jira=jira,  # type: ignore
             )
-            description = f"{link_line}\n{build_id_line}\n{classification_line}\n{failed_step_line}\n{failed_test_line}\n{job_history_link_line}\n"
             if past_bugs:
-                failed_test_portion = f" and failed test *{failed_test_name}*" if failed_test_name else ""
-                description += f"\n----\nHere are up to 10 related bugs produced by the step *{step_name}* and failed with failure type *{failure_type}*{failed_test_portion}:\n{self._get_past_bugs_table(issues=past_bugs, jira=jira)}\n"  # type: ignore
+                failed_test_portion = f" and failed test {failed_test_name}" if failed_test_name else ""
+                blocks.append(rule())
+                blocks.append(paragraph(inline_text(
+                    f"Here are up to 10 related bugs produced by the step {step_name} "
+                    f"and failed with failure type {failure_type}{failed_test_portion}:",
+                )))
+                blocks.append(self._get_past_bugs_table(issues=past_bugs, jira=jira))  # type: ignore
 
-        # If the issue is being created for a success
-        else:
-            description = f"{link_line}\n{build_id_line}"
+        issue_kind = "issue" if success_issue else "bug"
+        blocks.append(paragraph(
+            inline_text(f"This {issue_kind} was filed using "),
+            inline_text("firewatch in OpenShift CI", url=fw_url),
+            inline_text("."),
+        ))
 
-        description += f"\n{firewatch_link_line}"
-
-        return description
+        return adf_doc(*blocks)
 
     def _get_issue_labels(
         self,
@@ -938,27 +957,19 @@ class Report:
         # Reduce to 10 most recent issues
         return list_of_issues[:10]
 
-    def _get_past_bugs_table(self, issues: list[jira.Issue], jira: Jira) -> str:
-        """
-        Used to build the table of bugs related to a specific step/failure type that will be put in issue descriptions
-
-        Args:
-            issues (list[jira.Issue]): A list of jira issues.
-            jira (Jira): Jia object.
-
-        Returns:
-            str: A string object representing the table of related Jira issues to be put in a bug description.
-        """
-        table = "||Bug||Date Created||Assignee||"
-        issue_rows = []
-
+    def _get_past_bugs_table(self, issues: list[jira.Issue], jira: Jira) -> dict[str, Any]:
+        header = table_row(
+            table_header_cell(paragraph(inline_text("Bug", bold=True))),
+            table_header_cell(paragraph(inline_text("Date Created", bold=True))),
+            table_header_cell(paragraph(inline_text("Assignee", bold=True))),
+        )
+        rows = [header]
         for issue in issues:
             date_created = issue.get_field("created").split("T")[0]
-            assignee = issue.get_field("assignee")
-            issue_row = f"\n|[{issue.key}|{jira.url}/browse/{issue.key}]|{date_created}|{assignee}|"
-            issue_rows.append(issue_row)
-
-        for row in issue_rows:
-            table += row
-
-        return table
+            assignee = str(issue.get_field("assignee") or "Unassigned")
+            rows.append(table_row(
+                table_cell(paragraph(inline_text(issue.key, url=f"{jira.url}/browse/{issue.key}"))),
+                table_cell(paragraph(inline_text(date_created))),
+                table_cell(paragraph(inline_text(assignee))),
+            ))
+        return table(*rows)

--- a/src/report/report.py
+++ b/src/report/report.py
@@ -149,8 +149,8 @@ class Report:
                 rules=firewatch_config.failure_rules,  # type: ignore
                 default_jira_project=firewatch_config.default_jira_project,
             )
-            for rule in rule_matches:
-                rule_failure_pairs.append({"rule": rule, "failure": failure})
+            for failure_rule in rule_matches:
+                rule_failure_pairs.append({"rule": failure_rule, "failure": failure})
 
         rule_failure_pairs = self.filter_priority_rule_failure_pairs(
             rule_failure_pairs=rule_failure_pairs,
@@ -281,20 +281,20 @@ class Report:
         """
         self.logger.info(f"Reporting job {job.name} success.")
         date = datetime.now()
-        for rule in firewatch_config.success_rules if firewatch_config.success_rules else []:
+        for failure_rule in firewatch_config.success_rules if firewatch_config.success_rules else []:
             labels = [
                 label
                 for label in self._get_issue_labels(
                     job_name=job.name,
                     type="success",
-                    jira_additional_labels=rule.jira_additional_labels,  # type: ignore
+                    jira_additional_labels=failure_rule.jira_additional_labels,  # type: ignore
                     jira_additional_labels_filepath=firewatch_config.additional_labels_file,
-                    slack_channel=rule.slack_channel,  # type: ignore
-                    slack_user=rule.slack_user,  # type: ignore
+                    slack_channel=failure_rule.slack_channel,  # type: ignore
+                    slack_user=failure_rule.slack_user,  # type: ignore
                 )
                 if label
             ]
-            self._safe_create_success_issue(firewatch_config, job, rule, date, labels)
+            self._safe_create_success_issue(firewatch_config, job, failure_rule, date, labels)
 
     def _create_success_issue(
         self,
@@ -403,12 +403,12 @@ class Report:
         }
         default_rule = FailureRule(default_rule_dict)
 
-        for rule in rules:
-            if rule.matches_failure(failure):
-                if rule.ignore:
-                    ignored_rules.append(rule)
+        for failure_rule in rules:
+            if failure_rule.matches_failure(failure):
+                if failure_rule.ignore:
+                    ignored_rules.append(failure_rule)
                 else:
-                    matching_rules.append(rule)
+                    matching_rules.append(failure_rule)
 
         if (len(matching_rules) < 1) and (len(ignored_rules) < 1):
             if default_rule not in matching_rules:

--- a/src/report/report.py
+++ b/src/report/report.py
@@ -763,23 +763,31 @@ class Report:
         ]
 
         if not success_issue:
-            blocks.append(paragraph(
-                inline_text("Classification: ", bold=True),
-                inline_text(classification or ""),
-            ))
-            blocks.append(paragraph(
-                inline_text("Failed Step: ", bold=True),
-                inline_text(step_name or ""),
-            ))
+            blocks.append(
+                paragraph(
+                    inline_text("Classification: ", bold=True),
+                    inline_text(classification or ""),
+                )
+            )
+            blocks.append(
+                paragraph(
+                    inline_text("Failed Step: ", bold=True),
+                    inline_text(step_name or ""),
+                )
+            )
             if failed_test_name:
-                blocks.append(paragraph(
-                    inline_text("Failed Test: ", bold=True),
-                    inline_text(failed_test_name),
-                ))
-            blocks.append(paragraph(
-                inline_text("Job History: ", bold=True),
-                inline_text(job.name, url=job_history_url),
-            ))
+                blocks.append(
+                    paragraph(
+                        inline_text("Failed Test: ", bold=True),
+                        inline_text(failed_test_name or ""),
+                    )
+                )
+            blocks.append(
+                paragraph(
+                    inline_text("Job History: ", bold=True),
+                    inline_text(job.name or "", url=job_history_url),
+                )
+            )
 
             past_bugs = self._get_past_bugs(
                 failed_step=step_name,  # type: ignore
@@ -790,18 +798,24 @@ class Report:
             if past_bugs:
                 failed_test_portion = f" and failed test {failed_test_name}" if failed_test_name else ""
                 blocks.append(rule())
-                blocks.append(paragraph(inline_text(
-                    f"Here are up to 10 related bugs produced by the step {step_name} "
-                    f"and failed with failure type {failure_type}{failed_test_portion}:",
-                )))
+                blocks.append(
+                    paragraph(
+                        inline_text(
+                            f"Here are up to 10 related bugs produced by the step {step_name} "
+                            f"and failed with failure type {failure_type}{failed_test_portion}:",
+                        )
+                    )
+                )
                 blocks.append(self._get_past_bugs_table(issues=past_bugs, jira=jira))  # type: ignore
 
         issue_kind = "issue" if success_issue else "bug"
-        blocks.append(paragraph(
-            inline_text(f"This {issue_kind} was filed using "),
-            inline_text("firewatch in OpenShift CI", url=fw_url),
-            inline_text("."),
-        ))
+        blocks.append(
+            paragraph(
+                inline_text(f"This {issue_kind} was filed using "),
+                inline_text("firewatch in OpenShift CI", url=fw_url),
+                inline_text("."),
+            )
+        )
 
         return adf_doc(*blocks)
 
@@ -967,9 +981,11 @@ class Report:
         for issue in issues:
             date_created = issue.get_field("created").split("T")[0]
             assignee = str(issue.get_field("assignee") or "Unassigned")
-            rows.append(table_row(
-                table_cell(paragraph(inline_text(issue.key, url=f"{jira.url}/browse/{issue.key}"))),
-                table_cell(paragraph(inline_text(date_created))),
-                table_cell(paragraph(inline_text(assignee))),
-            ))
+            rows.append(
+                table_row(
+                    table_cell(paragraph(inline_text(issue.key, url=f"{jira.url}/browse/{issue.key}"))),
+                    table_cell(paragraph(inline_text(date_created))),
+                    table_cell(paragraph(inline_text(assignee))),
+                )
+            )
         return table(*rows)

--- a/tests/unittests/objects/jira/test_jira.py
+++ b/tests/unittests/objects/jira/test_jira.py
@@ -243,6 +243,27 @@ class TestCreateIssueAdfDescription:
         fields = call_kwargs["json"]["fields"]
         assert fields["description"]["content"][0]["content"][0]["text"] == " "
 
+    def test_create_issue_accepts_adf_dict_directly(self, mock_jira):
+        from src.objects.jira_adf import adf_doc, paragraph, inline_text
+
+        adf = adf_doc(
+            paragraph(inline_text("hello", bold=True)),
+        )
+        mock_jira.create_issue(
+            project="TEST",
+            summary="Summary",
+            description=adf,
+            issue_type="Bug",
+        )
+        call_kwargs = mock_jira.connection._session.post.call_args.kwargs
+        fields = call_kwargs["json"]["fields"]
+        desc = fields["description"]
+        assert desc["type"] == "doc"
+        assert desc["version"] == 1
+        assert desc["content"][0]["type"] == "paragraph"
+        assert desc["content"][0]["content"][0]["text"] == "hello"
+        assert {"type": "strong"} in desc["content"][0]["content"][0]["marks"]
+
 
 class TestCreateIssueEpicSearch:
     def test_epic_lookup_uses_unquoted_issue_key_for_cloud_compatibility(self, mock_jira):

--- a/tests/unittests/objects/jira/test_jira_adf.py
+++ b/tests/unittests/objects/jira/test_jira_adf.py
@@ -7,7 +7,12 @@ from src.objects.jira_adf import (
     inline_text,
     paragraph,
     plain_text_to_adf_doc,
+    rule,
     sanitize_jira_adf_doc,
+    table,
+    table_cell,
+    table_header_cell,
+    table_row,
 )
 
 
@@ -206,6 +211,38 @@ class TestDescriptionToPlainTextForSearch:
 
     def test_non_dict_non_str_returns_empty(self):
         assert description_to_plain_text_for_search(0) == ""  # type: ignore[arg-type]
+
+
+class TestRule:
+    def test_rule_produces_horizontal_divider(self):
+        assert rule() == {"type": "rule"}
+
+
+class TestTable:
+    def test_table_wraps_rows(self):
+        t = table(
+            table_row(table_header_cell(paragraph(inline_text("Col1")))),
+            table_row(table_cell(paragraph(inline_text("Val1")))),
+        )
+        assert t["type"] == "table"
+        assert len(t["content"]) == 2
+        assert t["content"][0]["type"] == "tableRow"
+        assert t["content"][0]["content"][0]["type"] == "tableHeader"
+        assert t["content"][1]["content"][0]["type"] == "tableCell"
+
+    def test_table_cell_contains_block_content(self):
+        cell = table_cell(paragraph(inline_text("data")))
+        assert cell == {
+            "type": "tableCell",
+            "content": [
+                {"type": "paragraph", "content": [{"type": "text", "text": "data"}]},
+            ],
+        }
+
+    def test_table_header_cell_type(self):
+        cell = table_header_cell(paragraph(inline_text("Header")))
+        assert cell["type"] == "tableHeader"
+        assert cell["content"][0]["content"][0]["text"] == "Header"
 
 
 class TestClosedByFirewatchAdf:


### PR DESCRIPTION
## Summary

- Issue descriptions created by firewatch render as raw wiki markup after the Jira Cloud migration because `_get_issue_description()` builds Jira Server wiki syntax (`*bold*`, `[text|url]`, `||header||`) and `create_issue()` wraps the result with `plain_text_to_adf_doc()`, dumping the markup into a single literal ADF text node.
- Comments (`add_duplicate_comment`, `add_passing_job_comment`) were already converted to ADF and work correctly. This PR applies the same pattern to descriptions.

## Changes

1. **`src/objects/jira_adf.py`** -- Added `rule()`, `table()`, `table_row()`, `table_header_cell()`, and `table_cell()` ADF helpers.
2. **`src/report/report.py`** -- Converted `_get_issue_description()` to return an ADF doc dict using `adf_doc()`, `paragraph()`, `inline_text()`. Converted `_get_past_bugs_table()` to return an ADF table using the new table helpers.
3. **`src/objects/jira_base.py`** -- Updated `create_issue()` to accept `str | dict` for the `description` parameter. Dict values (ADF) are sanitized directly; strings still go through `plain_text_to_adf_doc()` for backward compatibility.
4. **Tests** -- Added tests for new ADF helpers (rule, table, table_cell, table_header_cell) and a test for the dict pass-through path in `create_issue()`.

## Test plan

- [x] All 71 relevant unit tests pass
- [x] 257/261 total unit tests pass (4 pre-existing failures in `test_firewatch_report_cli_output_for_e2e_parity.py` due to `click` API incompatibility, unrelated to this change)

Fixes #271
Ref: INTEROP-8986